### PR TITLE
proposal: Phase 3 browser daemon

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -56,7 +56,7 @@ Migrating to Playwright on WhatsApp Web, following the same pattern as hey-cli.
 - [x] Human-like delays (random jitter between actions)
 
 ### Phase 3 — Performance
-- [ ] Browser daemon (forked Node process + Unix socket IPC + JSON-RPC)
+- [ ] Browser daemon (forked Node process + CDP via `connectOverCDP`)
 - [ ] Startup reduction: 3-5s -> ~200ms per invocation
 - [ ] Lazy start: first command auto-launches daemon
 - [ ] Auto-shutdown after 15min idle

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -56,9 +56,11 @@ Migrating to Playwright on WhatsApp Web, following the same pattern as hey-cli.
 - [x] Human-like delays (random jitter between actions)
 
 ### Phase 3 — Performance
-- [ ] Browser daemon (`chromium.launchServer()` + WebSocket connect)
+- [ ] Browser daemon (forked Node process + Unix socket IPC + JSON-RPC)
 - [ ] Startup reduction: 3-5s -> ~200ms per invocation
-- [ ] `greentap status` — check if daemon is running
+- [ ] Lazy start: first command auto-launches daemon
+- [ ] Auto-shutdown after 15min idle
+- [ ] `greentap status` / `greentap daemon stop`
 
 ### Phase 4 — Deprecate AX
 - [ ] Remove Swift codebase

--- a/openspec/changes/browser-daemon/.openspec.yaml
+++ b/openspec/changes/browser-daemon/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-07

--- a/openspec/changes/browser-daemon/design.md
+++ b/openspec/changes/browser-daemon/design.md
@@ -32,15 +32,36 @@ framing, no message serialization to build.
 
 Client `browser.close()` only disconnects the client — Chrome stays alive.
 
+**Alternative rejected:** `browserType.launchServer()` + `connect()` — Playwright's native
+server mode has full-fidelity WS protocol, but explicitly blocks `--user-data-dir`. We need
+persistent context for the WhatsApp session. Tested: Playwright throws
+`"Pass userDataDir to launchPersistentContext instead"` when args include `--user-data-dir`.
+
 **Alternative rejected:** Custom Unix socket + JSON-RPC — unnecessary complexity
 now that we confirmed CDP works with persistent contexts.
+
+**Fidelity note:** Playwright docs warn that `connectOverCDP` offers "significantly lower
+fidelity" than the native protocol. Tested in practice: `ariaSnapshot`, `locator`,
+`getByRole`, `keyboard.type`, `evaluate`, `waitForSelector` all work correctly over CDP.
+The warning applies to edge cases irrelevant to our use case.
+
+### CDP port: fixed at 19222
+
+**Why:** `--remote-debugging-port=0` auto-assigns a port, but discovering it requires
+`lsof` or process scanning — fragile and platform-specific. A fixed port (19222) is
+simpler: daemon writes it to `daemon.port` for consistency, client reads it, done.
+Single-user localhost tool, port conflicts are unlikely. If 19222 is taken, daemon
+fails fast with a clear error.
+
+**Alternative rejected:** Port 0 + discovery via `lsof -p PID` — unnecessary complexity
+for a personal single-instance tool.
 
 ### Daemon: forked Node process
 
 **Why:** `child_process.fork()` with `detached: true`, `unref()`, and `stdio: 'ignore'`.
 The daemon script (`lib/daemon.js`):
-1. Launches `launchPersistentContext` with `--remote-debugging-port=0` (auto-assign)
-2. Writes allocated port to `~/.greentap/daemon.port`
+1. Launches `launchPersistentContext` with `--remote-debugging-port=19222`
+2. Writes port to `~/.greentap/daemon.port`
 3. Writes PID to `~/.greentap/daemon.pid`
 4. Navigates to WhatsApp Web, waits for chat list
 5. Starts idle timer
@@ -79,10 +100,9 @@ Daemon starts
   │
   ├─ Ensure ~/.greentap/ is mode 0700
   ├─ Launch Chrome: launchPersistentContext(browser-data, {
-  │     args: ['--remote-debugging-port=0']
+  │     args: ['--remote-debugging-port=19222']
   │   })
-  ├─ Get allocated port from Chrome
-  ├─ Write port to ~/.greentap/daemon.port (atomic: .tmp + rename)
+  ├─ Write 19222 to ~/.greentap/daemon.port (atomic: .tmp + rename)
   ├─ Write PID to ~/.greentap/daemon.pid (atomic: .tmp + rename)
   ├─ Navigate to web.whatsapp.com
   ├─ Wait for chat list grid

--- a/openspec/changes/browser-daemon/design.md
+++ b/openspec/changes/browser-daemon/design.md
@@ -88,8 +88,8 @@ Daemon starts
   ├─ Wait for chat list grid
   ├─ Start idle timer (15 min)
   │
-  ├─ Idle timer reset: touch daemon.port mtime on each client connect
-  │   (client touches file after connecting, daemon watches mtime)
+  ├─ Idle timer reset: daemon detects CDP client connect/disconnect events
+  │   (Chrome emits Target.attachedToTarget / detachedFromTarget)
   │
   └─ On idle timeout OR SIGTERM:
       ├─ Close browser context (kills Chrome)
@@ -112,7 +112,7 @@ executing, which implicitly waits for any prior navigation to complete.
 - `~/.greentap/` directory: `0700`
 - `daemon.port`: `0600`, written atomically
 - `daemon.pid`: `0600`, written atomically
-- `daemon.lock`: exclusive lock via `fs.open()` with `O_EXCL` to prevent startup races
+- `daemon.lock`: exclusive lock via `flock()` (auto-releases on crash) to prevent startup races
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/browser-daemon/design.md
+++ b/openspec/changes/browser-daemon/design.md
@@ -1,0 +1,116 @@
+## Context
+
+Currently every greentap command calls `withBrowser()` which runs
+`chromium.launchPersistentContext()` → work → `context.close()`. This takes 3-5s per
+invocation, mostly Chrome startup + WhatsApp Web load.
+
+Playwright's `launchPersistentContext()` returns a `BrowserContext` (not `Browser`),
+so `chromium.launchServer()` + `connectOverCDP()` won't work directly — the daemon
+must hold the context itself and expose commands over IPC.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Per-command latency < 500ms when daemon is running
+- Zero-config: first command auto-starts daemon, idle timeout auto-stops it
+- Explicit `daemon stop` and `status` commands
+- Clean shutdown: PID file, socket cleanup, no orphan Chrome processes
+
+**Non-Goals:**
+- Multi-user / multi-session support
+- Remote access (daemon is localhost only)
+- Keeping WhatsApp Web page navigated to a specific chat between commands
+
+## Decisions
+
+### IPC: Unix domain socket with JSON-RPC
+
+**Why:** Simple, fast, no extra dependencies. Node `net` module handles it natively.
+Named pipes are cross-platform but we only need macOS. HTTP would work but adds
+overhead and complexity.
+
+**Alternative considered:** WebSocket via `launchServer()` — can't use because
+`launchPersistentContext` doesn't support server mode.
+
+### Daemon: forked Node process
+
+**Why:** `child_process.fork()` with `detached: true` + `unref()`. The daemon is a
+standalone Node script (`lib/daemon.js`) that holds the browser context and listens
+on the socket. CLI commands send JSON-RPC messages and receive results.
+
+**Alternative considered:** Background shell process (`&`) — harder to manage lifecycle,
+no clean IPC.
+
+### Idle timeout: 15 minutes
+
+**Why:** Covers typical interactive sessions (check → read → send: 2-5 min) with margin.
+Long enough to not restart mid-workflow, short enough to not waste RAM overnight.
+Timer resets on each command.
+
+**Alternative considered:** Configurable via env var — YAGNI for personal use.
+Can add later if needed.
+
+### Connection flow
+
+```
+CLI command (e.g. greentap chats)
+  │
+  ├─ Try connect to ~/.greentap/daemon.sock
+  │   ├─ Success → send command → receive result
+  │   └─ Fail (ECONNREFUSED / ENOENT)
+  │       ├─ Fork daemon process
+  │       ├─ Wait for socket to appear (poll, max 10s)
+  │       └─ Connect → send command → receive result
+  │
+  └─ Print result / exit
+```
+
+### Daemon lifecycle
+
+```
+Daemon starts
+  │
+  ├─ Write PID to ~/.greentap/daemon.pid
+  ├─ Launch Chrome with launchPersistentContext()
+  ├─ Navigate to web.whatsapp.com
+  ├─ Wait for chat list grid
+  ├─ Create Unix socket server at ~/.greentap/daemon.sock
+  ├─ Start idle timer (15 min)
+  │
+  ├─ On client connection:
+  │   ├─ Reset idle timer
+  │   ├─ Execute command on the existing page
+  │   └─ Return JSON result
+  │
+  └─ On idle timeout OR SIGTERM:
+      ├─ Close browser context
+      ├─ Remove PID file
+      ├─ Remove socket file
+      └─ Exit
+```
+
+### Command protocol (JSON-RPC over socket)
+
+Request: `{ "method": "chats", "params": { "json": true } }`
+Response: `{ "result": [...] }` or `{ "error": "message" }`
+
+Each command maps to the existing `cmd*` functions, but operating on the
+daemon's persistent page instead of launching a new browser.
+
+## Risks / Trade-offs
+
+- **WhatsApp Web disconnects after long idle** → Daemon should detect "use your phone"
+  overlay and re-navigate. If session expired, report error and suggest `greentap login`.
+
+- **Chrome crash / OOM** → Daemon should catch browser disconnect event, clean up
+  PID/socket, and exit. Next CLI invocation will auto-start a fresh daemon.
+
+- **Stale PID file after crash** → On startup, check if PID is alive before connecting.
+  If PID file exists but process is dead, clean up and start fresh.
+
+- **RAM usage (~200-400MB)** → Acceptable for personal Mac use. Auto-shutdown at 15min
+  limits exposure.
+
+- **Page state between commands** → Each command should ensure the page is in a known
+  state (main chat list view) before executing. Navigate to WA_URL if needed, or at
+  minimum wait for chat list grid.

--- a/openspec/changes/browser-daemon/design.md
+++ b/openspec/changes/browser-daemon/design.md
@@ -4,9 +4,9 @@ Currently every greentap command calls `withBrowser()` which runs
 `chromium.launchPersistentContext()` → work → `context.close()`. This takes 3-5s per
 invocation, mostly Chrome startup + WhatsApp Web load.
 
-Playwright's `launchPersistentContext()` returns a `BrowserContext` (not `Browser`),
-so `chromium.launchServer()` + `connectOverCDP()` won't work directly — the daemon
-must hold the context itself and expose commands over IPC.
+Key discovery: `launchPersistentContext` with `--remote-debugging-port` exposes
+a CDP endpoint. Clients can then use `chromium.connectOverCDP()` to get the same
+context and pages — full Playwright API, no custom IPC needed.
 
 ## Goals / Non-Goals
 
@@ -14,53 +14,60 @@ must hold the context itself and expose commands over IPC.
 - Per-command latency < 500ms when daemon is running
 - Zero-config: first command auto-starts daemon, idle timeout auto-stops it
 - Explicit `daemon stop` and `status` commands
-- Clean shutdown: PID file, socket cleanup, no orphan Chrome processes
+- Clean shutdown: PID file, port file cleanup, no orphan Chrome processes
 
 **Non-Goals:**
 - Multi-user / multi-session support
 - Remote access (daemon is localhost only)
-- Keeping WhatsApp Web page navigated to a specific chat between commands
+- Custom IPC protocol (use Playwright's native CDP transport)
 
 ## Decisions
 
-### IPC: Unix domain socket with JSON-RPC
+### IPC: Chrome DevTools Protocol via Playwright
 
-**Why:** Simple, fast, no extra dependencies. Node `net` module handles it natively.
-Named pipes are cross-platform but we only need macOS. HTTP would work but adds
-overhead and complexity.
+**Why:** `launchPersistentContext` with `--remote-debugging-port=PORT` exposes a CDP
+endpoint. Clients connect with `chromium.connectOverCDP('http://localhost:PORT')` and
+get the full Playwright API — same context, same pages. No JSON-RPC, no socket
+framing, no message serialization to build.
 
-**Alternative considered:** WebSocket via `launchServer()` — can't use because
-`launchPersistentContext` doesn't support server mode.
+Client `browser.close()` only disconnects the client — Chrome stays alive.
+
+**Alternative rejected:** Custom Unix socket + JSON-RPC — unnecessary complexity
+now that we confirmed CDP works with persistent contexts.
 
 ### Daemon: forked Node process
 
-**Why:** `child_process.fork()` with `detached: true` + `unref()`. The daemon is a
-standalone Node script (`lib/daemon.js`) that holds the browser context and listens
-on the socket. CLI commands send JSON-RPC messages and receive results.
-
-**Alternative considered:** Background shell process (`&`) — harder to manage lifecycle,
-no clean IPC.
+**Why:** `child_process.fork()` with `detached: true`, `unref()`, and `stdio: 'ignore'`.
+The daemon script (`lib/daemon.js`):
+1. Launches `launchPersistentContext` with `--remote-debugging-port=0` (auto-assign)
+2. Writes allocated port to `~/.greentap/daemon.port`
+3. Writes PID to `~/.greentap/daemon.pid`
+4. Navigates to WhatsApp Web, waits for chat list
+5. Starts idle timer
 
 ### Idle timeout: 15 minutes
 
-**Why:** Covers typical interactive sessions (check → read → send: 2-5 min) with margin.
-Long enough to not restart mid-workflow, short enough to not waste RAM overnight.
-Timer resets on each command.
-
-**Alternative considered:** Configurable via env var — YAGNI for personal use.
-Can add later if needed.
+**Why:** Covers typical interactive sessions with margin. Timer resets each time
+a client connects (daemon can detect connections via CDP events or a simple
+heartbeat file touch).
 
 ### Connection flow
 
 ```
 CLI command (e.g. greentap chats)
   │
-  ├─ Try connect to ~/.greentap/daemon.sock
-  │   ├─ Success → send command → receive result
-  │   └─ Fail (ECONNREFUSED / ENOENT)
+  ├─ Read ~/.greentap/daemon.port
+  │   ├─ Exists → connectOverCDP(http://localhost:PORT)
+  │   │   ├─ Success → get page → execute command → disconnect
+  │   │   └─ Fail → stale file, clean up, fall through
+  │   └─ Missing
+  │       ├─ Check browser-data/ exists (has session?)
+  │       │   └─ No → "Run greentap login first"
+  │       ├─ Acquire exclusive lock (~/.greentap/daemon.lock)
   │       ├─ Fork daemon process
-  │       ├─ Wait for socket to appear (poll, max 10s)
-  │       └─ Connect → send command → receive result
+  │       ├─ Wait for daemon.port file to appear (poll, max 15s)
+  │       ├─ Release lock
+  │       └─ connectOverCDP → execute command → disconnect
   │
   └─ Print result / exit
 ```
@@ -70,47 +77,63 @@ CLI command (e.g. greentap chats)
 ```
 Daemon starts
   │
-  ├─ Write PID to ~/.greentap/daemon.pid
-  ├─ Launch Chrome with launchPersistentContext()
+  ├─ Ensure ~/.greentap/ is mode 0700
+  ├─ Launch Chrome: launchPersistentContext(browser-data, {
+  │     args: ['--remote-debugging-port=0']
+  │   })
+  ├─ Get allocated port from Chrome
+  ├─ Write port to ~/.greentap/daemon.port (atomic: .tmp + rename)
+  ├─ Write PID to ~/.greentap/daemon.pid (atomic: .tmp + rename)
   ├─ Navigate to web.whatsapp.com
   ├─ Wait for chat list grid
-  ├─ Create Unix socket server at ~/.greentap/daemon.sock
   ├─ Start idle timer (15 min)
   │
-  ├─ On client connection:
-  │   ├─ Reset idle timer
-  │   ├─ Execute command on the existing page
-  │   └─ Return JSON result
+  ├─ Idle timer reset: touch daemon.port mtime on each client connect
+  │   (client touches file after connecting, daemon watches mtime)
   │
   └─ On idle timeout OR SIGTERM:
-      ├─ Close browser context
-      ├─ Remove PID file
-      ├─ Remove socket file
+      ├─ Close browser context (kills Chrome)
+      ├─ Remove port file, PID file, lock file
       └─ Exit
 ```
 
-### Command protocol (JSON-RPC over socket)
+### Command serialization
 
-Request: `{ "method": "chats", "params": { "json": true } }`
-Response: `{ "result": [...] }` or `{ "error": "message" }`
+Playwright's CDP transport handles one command at a time per page. Since each
+CLI invocation connects, uses the page, and disconnects, and typical CLI usage
+is sequential, we don't need an explicit queue. If two clients connect
+simultaneously, Playwright's internal protocol handles ordering.
 
-Each command maps to the existing `cmd*` functions, but operating on the
-daemon's persistent page instead of launching a new browser.
+For safety: each command should verify page state (chat list visible) before
+executing, which implicitly waits for any prior navigation to complete.
+
+### File permissions
+
+- `~/.greentap/` directory: `0700`
+- `daemon.port`: `0600`, written atomically
+- `daemon.pid`: `0600`, written atomically
+- `daemon.lock`: exclusive lock via `fs.open()` with `O_EXCL` to prevent startup races
 
 ## Risks / Trade-offs
 
-- **WhatsApp Web disconnects after long idle** → Daemon should detect "use your phone"
-  overlay and re-navigate. If session expired, report error and suggest `greentap login`.
+- **CDP port exposed on localhost** → Only accessible to local processes with
+  same user permissions (port bound to 127.0.0.1 by default). Combined with
+  `~/.greentap/` dir at `0700`, port number is not discoverable by other users.
 
-- **Chrome crash / OOM** → Daemon should catch browser disconnect event, clean up
-  PID/socket, and exit. Next CLI invocation will auto-start a fresh daemon.
+- **WhatsApp Web disconnects after long idle** → Daemon should detect failure
+  on client connect (page in bad state). Try `page.reload()`; if session expired,
+  return error suggesting `greentap login`.
 
-- **Stale PID file after crash** → On startup, check if PID is alive before connecting.
-  If PID file exists but process is dead, clean up and start fresh.
+- **Chrome crash / OOM** → Daemon catches browser `disconnected` event, cleans
+  up files, and exits. Next CLI invocation auto-starts fresh.
 
-- **RAM usage (~200-400MB)** → Acceptable for personal Mac use. Auto-shutdown at 15min
-  limits exposure.
+- **Stale port file after crash** → Client reads port, tries `connectOverCDP`,
+  gets connection refused. Cleans up stale files and starts fresh daemon (under lock).
 
-- **Page state between commands** → Each command should ensure the page is in a known
-  state (main chat list view) before executing. Navigate to WA_URL if needed, or at
-  minimum wait for chat list grid.
+- **RAM usage (~200-400MB)** → Acceptable for personal Mac. Auto-shutdown limits exposure.
+
+- **Page state between commands** → Each command checks chat list grid. Try
+  Escape (dismiss overlays) → `page.reload()` → `page.goto(WA_URL)` as escalation.
+
+- **Lazy start with no session** → If `browser-data/` is empty, skip daemon
+  auto-start; tell user to run `greentap login` first.

--- a/openspec/changes/browser-daemon/proposal.md
+++ b/openspec/changes/browser-daemon/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Every greentap command pays a 3-5s startup tax to launch Chrome and load WhatsApp Web.
+For interactive use (check unread → read chat → send reply) this means 10-15s of waiting
+across 3 commands. A persistent browser process would reduce per-command latency to ~200ms.
+
+## What Changes
+
+- New daemon process that keeps Chrome + WhatsApp Web alive between commands
+- CLI commands connect to the running daemon instead of launching a new browser
+- Lazy start: first command auto-launches the daemon if not running
+- Auto-shutdown after idle timeout to reclaim resources
+- `greentap status` command to check daemon state
+- `greentap daemon stop` to explicitly kill the daemon
+
+## Capabilities
+
+### New Capabilities
+- `browser-daemon`: Persistent browser process with Unix socket IPC, lazy start, and idle auto-shutdown
+- `daemon-lifecycle`: Start, stop, status commands and auto-shutdown behavior
+
+### Modified Capabilities
+- `browser-wait`: Commands connect to existing daemon instead of launching new browser
+
+## Impact
+
+- `greentap.js`: `withBrowser()` changes from launch/close to connect/disconnect
+- New file: `lib/daemon.js` — daemon process, socket server, idle timer
+- PID and socket files at `~/.greentap/daemon.pid`, `~/.greentap/daemon.sock`
+- Chrome process stays resident (~200-400MB RAM when idle)
+- Playwright `launchPersistentContext` must be held by daemon (not per-command)

--- a/openspec/changes/browser-daemon/specs/browser-daemon/spec.md
+++ b/openspec/changes/browser-daemon/specs/browser-daemon/spec.md
@@ -3,43 +3,37 @@
 ### Requirement: Persistent browser via daemon process
 
 The system SHALL maintain a background Node process that holds a Playwright
-persistent browser context with WhatsApp Web loaded, accessible via Unix socket
-at `~/.greentap/daemon.sock`.
+persistent browser context with Chrome DevTools Protocol exposed on localhost.
 
-#### Scenario: Daemon starts and accepts connections
+#### Scenario: Daemon starts and exposes CDP
 
 - **WHEN** the daemon process starts
-- **THEN** it SHALL launch Chrome with `launchPersistentContext`
+- **THEN** it SHALL launch Chrome with `launchPersistentContext` and `--remote-debugging-port=0`
+- **AND** ensure `~/.greentap/` directory is mode `0700`
+- **AND** write the allocated port to `~/.greentap/daemon.port` atomically (mode `0600`)
+- **AND** write its PID to `~/.greentap/daemon.pid` atomically (mode `0600`)
 - **AND** navigate to `web.whatsapp.com`
 - **AND** wait for the chat list grid to appear
-- **AND** create a Unix socket server at `~/.greentap/daemon.sock`
-- **AND** write its PID to `~/.greentap/daemon.pid`
 
-#### Scenario: CLI command connects to running daemon
+#### Scenario: CLI command connects via CDP
 
-- **WHEN** a CLI command executes and `~/.greentap/daemon.sock` exists and is connectable
-- **THEN** the command SHALL send a JSON-RPC request over the socket
-- **AND** receive the result without launching a new browser
+- **WHEN** a CLI command executes and `~/.greentap/daemon.port` exists
+- **THEN** the command SHALL read the port and call `chromium.connectOverCDP`
+- **AND** get the persistent context and page via Playwright's native API
+- **AND** execute the command directly on the page
+- **AND** disconnect (without closing Chrome)
 
 #### Scenario: Lazy start when no daemon running
 
-- **WHEN** a CLI command executes and no daemon is running (socket doesn't exist or connection refused)
-- **THEN** the CLI SHALL fork a new daemon process (detached)
-- **AND** wait for the socket to become connectable (max 15s)
-- **AND** then send the command
+- **WHEN** a CLI command executes and no daemon is running (port file missing or connection refused)
+- **THEN** the CLI SHALL acquire an exclusive lock on `~/.greentap/daemon.lock`
+- **AND** fork a new daemon process (detached, `stdio: 'ignore'`)
+- **AND** wait for `daemon.port` file to appear (max 15s)
+- **AND** release the lock
+- **AND** connect via CDP and execute the command
 
-### Requirement: JSON-RPC command protocol
+#### Scenario: Stale port file
 
-The daemon SHALL accept JSON-RPC messages over the Unix socket.
-
-#### Scenario: Command request and response
-
-- **WHEN** a client sends `{ "method": "<command>", "params": { ... } }`
-- **THEN** the daemon SHALL execute the command on its persistent page
-- **AND** return `{ "result": <data> }` on success
-- **OR** return `{ "error": "<message>" }` on failure
-
-#### Scenario: Supported methods
-
-- **WHEN** the method is one of: `chats`, `unread`, `read`, `send`, `search`, `snapshot`
-- **THEN** the daemon SHALL execute the corresponding command logic
+- **WHEN** a CLI command reads `daemon.port` but `connectOverCDP` fails
+- **THEN** it SHALL remove the stale port and PID files
+- **AND** start a fresh daemon (under lock)

--- a/openspec/changes/browser-daemon/specs/browser-daemon/spec.md
+++ b/openspec/changes/browser-daemon/specs/browser-daemon/spec.md
@@ -8,9 +8,9 @@ persistent browser context with Chrome DevTools Protocol exposed on localhost.
 #### Scenario: Daemon starts and exposes CDP
 
 - **WHEN** the daemon process starts
-- **THEN** it SHALL launch Chrome with `launchPersistentContext` and `--remote-debugging-port=0`
+- **THEN** it SHALL launch Chrome with `launchPersistentContext` and `--remote-debugging-port=19222`
 - **AND** ensure `~/.greentap/` directory is mode `0700`
-- **AND** write the allocated port to `~/.greentap/daemon.port` atomically (mode `0600`)
+- **AND** write the port (`19222`) to `~/.greentap/daemon.port` atomically (mode `0600`)
 - **AND** write its PID to `~/.greentap/daemon.pid` atomically (mode `0600`)
 - **AND** navigate to `web.whatsapp.com`
 - **AND** wait for the chat list grid to appear

--- a/openspec/changes/browser-daemon/specs/browser-daemon/spec.md
+++ b/openspec/changes/browser-daemon/specs/browser-daemon/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Persistent browser via daemon process
+
+The system SHALL maintain a background Node process that holds a Playwright
+persistent browser context with WhatsApp Web loaded, accessible via Unix socket
+at `~/.greentap/daemon.sock`.
+
+#### Scenario: Daemon starts and accepts connections
+
+- **WHEN** the daemon process starts
+- **THEN** it SHALL launch Chrome with `launchPersistentContext`
+- **AND** navigate to `web.whatsapp.com`
+- **AND** wait for the chat list grid to appear
+- **AND** create a Unix socket server at `~/.greentap/daemon.sock`
+- **AND** write its PID to `~/.greentap/daemon.pid`
+
+#### Scenario: CLI command connects to running daemon
+
+- **WHEN** a CLI command executes and `~/.greentap/daemon.sock` exists and is connectable
+- **THEN** the command SHALL send a JSON-RPC request over the socket
+- **AND** receive the result without launching a new browser
+
+#### Scenario: Lazy start when no daemon running
+
+- **WHEN** a CLI command executes and no daemon is running (socket doesn't exist or connection refused)
+- **THEN** the CLI SHALL fork a new daemon process (detached)
+- **AND** wait for the socket to become connectable (max 15s)
+- **AND** then send the command
+
+### Requirement: JSON-RPC command protocol
+
+The daemon SHALL accept JSON-RPC messages over the Unix socket.
+
+#### Scenario: Command request and response
+
+- **WHEN** a client sends `{ "method": "<command>", "params": { ... } }`
+- **THEN** the daemon SHALL execute the command on its persistent page
+- **AND** return `{ "result": <data> }` on success
+- **OR** return `{ "error": "<message>" }` on failure
+
+#### Scenario: Supported methods
+
+- **WHEN** the method is one of: `chats`, `unread`, `read`, `send`, `search`, `snapshot`
+- **THEN** the daemon SHALL execute the corresponding command logic

--- a/openspec/changes/browser-daemon/specs/browser-wait/spec.md
+++ b/openspec/changes/browser-daemon/specs/browser-wait/spec.md
@@ -8,9 +8,9 @@ falling back to direct browser launch for `login` command only.
 #### Scenario: Command uses daemon when available
 
 - **WHEN** any command except `login` executes
-- **THEN** it SHALL attempt to connect to the daemon via Unix socket
+- **THEN** it SHALL attempt to connect to the daemon via `chromium.connectOverCDP`
 - **AND** if daemon is not running, auto-start it
-- **AND** execute the command via daemon IPC
+- **AND** execute the command on the connected page
 
 #### Scenario: Login command bypasses daemon
 

--- a/openspec/changes/browser-daemon/specs/browser-wait/spec.md
+++ b/openspec/changes/browser-daemon/specs/browser-wait/spec.md
@@ -23,3 +23,9 @@ falling back to direct browser launch for `login` command only.
 - **WHEN** user runs `greentap logout`
 - **THEN** it SHALL stop the daemon if running
 - **AND** then clear `~/.greentap/browser-data/`
+
+#### Scenario: No session exists
+
+- **WHEN** any command executes and `~/.greentap/browser-data/` is empty or missing
+- **THEN** it SHALL NOT auto-start the daemon
+- **AND** print "No session. Run `greentap login` first."

--- a/openspec/changes/browser-daemon/specs/browser-wait/spec.md
+++ b/openspec/changes/browser-daemon/specs/browser-wait/spec.md
@@ -1,0 +1,25 @@
+## MODIFIED Requirements
+
+### Requirement: Browser connection strategy
+
+The `withBrowser` helper SHALL connect to an existing daemon when available,
+falling back to direct browser launch for `login` command only.
+
+#### Scenario: Command uses daemon when available
+
+- **WHEN** any command except `login` executes
+- **THEN** it SHALL attempt to connect to the daemon via Unix socket
+- **AND** if daemon is not running, auto-start it
+- **AND** execute the command via daemon IPC
+
+#### Scenario: Login command bypasses daemon
+
+- **WHEN** user runs `greentap login`
+- **THEN** it SHALL launch a headed browser directly (not through daemon)
+- **AND** the daemon SHALL NOT be started or used
+
+#### Scenario: Logout stops daemon
+
+- **WHEN** user runs `greentap logout`
+- **THEN** it SHALL stop the daemon if running
+- **AND** then clear `~/.greentap/browser-data/`

--- a/openspec/changes/browser-daemon/specs/daemon-lifecycle/spec.md
+++ b/openspec/changes/browser-daemon/specs/daemon-lifecycle/spec.md
@@ -1,0 +1,67 @@
+## ADDED Requirements
+
+### Requirement: Auto-shutdown on idle
+
+The daemon SHALL automatically shut down after 15 minutes of no client commands.
+
+#### Scenario: Idle timeout triggers shutdown
+
+- **WHEN** no client connects for 15 minutes
+- **THEN** the daemon SHALL close the browser context
+- **AND** remove `~/.greentap/daemon.sock`
+- **AND** remove `~/.greentap/daemon.pid`
+- **AND** exit the process
+
+#### Scenario: Activity resets idle timer
+
+- **WHEN** a client sends a command
+- **THEN** the idle timer SHALL reset to 15 minutes
+
+### Requirement: Explicit stop command
+
+#### Scenario: greentap daemon stop
+
+- **WHEN** user runs `greentap daemon stop`
+- **THEN** the CLI SHALL send a shutdown signal to the daemon via socket
+- **AND** the daemon SHALL perform clean shutdown (close browser, remove PID/socket)
+
+#### Scenario: Stop when no daemon running
+
+- **WHEN** user runs `greentap daemon stop` and no daemon is running
+- **THEN** the CLI SHALL print "No daemon running."
+
+### Requirement: Status command
+
+#### Scenario: greentap status with daemon running
+
+- **WHEN** user runs `greentap status` and daemon is running
+- **THEN** the CLI SHALL print daemon PID, uptime, and idle time
+
+#### Scenario: greentap status with no daemon
+
+- **WHEN** user runs `greentap status` and no daemon is running
+- **THEN** the CLI SHALL print "No daemon running."
+
+### Requirement: Crash recovery
+
+#### Scenario: Stale PID file from crashed daemon
+
+- **WHEN** a CLI command finds `daemon.pid` but the process is not alive
+- **THEN** it SHALL remove the stale PID and socket files
+- **AND** start a fresh daemon
+
+#### Scenario: Browser disconnect during operation
+
+- **WHEN** Chrome crashes or disconnects while daemon is running
+- **THEN** the daemon SHALL clean up PID and socket files
+- **AND** exit with a non-zero code
+
+### Requirement: Page state reset between commands
+
+The daemon SHALL ensure the page is in a usable state before executing each command.
+
+#### Scenario: Navigate back to chat list if needed
+
+- **WHEN** a command is received and the chat list grid is not visible
+- **THEN** the daemon SHALL navigate to `web.whatsapp.com` and wait for the chat list
+- **AND** then execute the command

--- a/openspec/changes/browser-daemon/specs/daemon-lifecycle/spec.md
+++ b/openspec/changes/browser-daemon/specs/daemon-lifecycle/spec.md
@@ -2,19 +2,18 @@
 
 ### Requirement: Auto-shutdown on idle
 
-The daemon SHALL automatically shut down after 15 minutes of no client commands.
+The daemon SHALL automatically shut down after 15 minutes of no client connections.
 
 #### Scenario: Idle timeout triggers shutdown
 
 - **WHEN** no client connects for 15 minutes
 - **THEN** the daemon SHALL close the browser context
-- **AND** remove `~/.greentap/daemon.sock`
-- **AND** remove `~/.greentap/daemon.pid`
+- **AND** remove `~/.greentap/daemon.port`, `daemon.pid`, `daemon.lock`
 - **AND** exit the process
 
 #### Scenario: Activity resets idle timer
 
-- **WHEN** a client sends a command
+- **WHEN** a client connects via CDP
 - **THEN** the idle timer SHALL reset to 15 minutes
 
 ### Requirement: Explicit stop command
@@ -22,8 +21,8 @@ The daemon SHALL automatically shut down after 15 minutes of no client commands.
 #### Scenario: greentap daemon stop
 
 - **WHEN** user runs `greentap daemon stop`
-- **THEN** the CLI SHALL send a shutdown signal to the daemon via socket
-- **AND** the daemon SHALL perform clean shutdown (close browser, remove PID/socket)
+- **THEN** the CLI SHALL send SIGTERM to the daemon PID
+- **AND** the daemon SHALL perform clean shutdown (close browser, remove files)
 
 #### Scenario: Stop when no daemon running
 
@@ -35,7 +34,7 @@ The daemon SHALL automatically shut down after 15 minutes of no client commands.
 #### Scenario: greentap status with daemon running
 
 - **WHEN** user runs `greentap status` and daemon is running
-- **THEN** the CLI SHALL print daemon PID, uptime, and idle time
+- **THEN** the CLI SHALL print daemon PID and CDP port
 
 #### Scenario: greentap status with no daemon
 
@@ -44,24 +43,18 @@ The daemon SHALL automatically shut down after 15 minutes of no client commands.
 
 ### Requirement: Crash recovery
 
-#### Scenario: Stale PID file from crashed daemon
-
-- **WHEN** a CLI command finds `daemon.pid` but the process is not alive
-- **THEN** it SHALL remove the stale PID and socket files
-- **AND** start a fresh daemon
-
 #### Scenario: Browser disconnect during operation
 
 - **WHEN** Chrome crashes or disconnects while daemon is running
-- **THEN** the daemon SHALL clean up PID and socket files
+- **THEN** the daemon SHALL clean up port, PID, and lock files
 - **AND** exit with a non-zero code
 
-### Requirement: Page state reset between commands
+### Requirement: WhatsApp Web session recovery
 
-The daemon SHALL ensure the page is in a usable state before executing each command.
+#### Scenario: WA disconnects or shows overlay
 
-#### Scenario: Navigate back to chat list if needed
-
-- **WHEN** a command is received and the chat list grid is not visible
-- **THEN** the daemon SHALL navigate to `web.whatsapp.com` and wait for the chat list
-- **AND** then execute the command
+- **WHEN** a client connects and the page is in a bad state (no chat list grid)
+- **THEN** the client SHALL try pressing Escape (dismiss overlays)
+- **AND** if still not visible, try `page.reload()`
+- **AND** only as last resort, `page.goto(WA_URL)`
+- **AND** if recovery fails, throw error suggesting `greentap login`

--- a/openspec/changes/browser-daemon/tasks.md
+++ b/openspec/changes/browser-daemon/tasks.md
@@ -7,14 +7,14 @@
 
 - [ ] 2.1 Create `lib/daemon.js` — launches `launchPersistentContext` with `--remote-debugging-port=0`, writes port + PID files atomically, navigates to WA, waits for chat list
 - [ ] 2.2 Ensure `~/.greentap/` dir is `0700`, port/PID files are `0600`
-- [ ] 2.3 Implement idle timer (15min) — reset when `daemon.port` mtime changes, clean shutdown on expiry
+- [ ] 2.3 Implement idle timer (15min) — reset on CDP client connect/disconnect events, clean shutdown on expiry
 - [ ] 2.4 Handle browser `disconnected` event — clean up files and exit
 - [ ] 2.5 Handle SIGTERM — clean shutdown
 
 ## 3. CLI client
 
 - [ ] 3.1 Create `lib/client.js` — read `daemon.port`, `connectOverCDP`, return `{ browser, context, page }`; on disconnect call `browser.close()` (doesn't kill Chrome)
-- [ ] 3.2 Implement lazy start with exclusive lock: acquire `daemon.lock`, fork `lib/daemon.js` detached with `stdio: 'ignore'`, poll for `daemon.port` (max 15s), release lock
+- [ ] 3.2 Implement lazy start with exclusive lock: acquire `daemon.lock` via `flock()`, fork `lib/daemon.js` detached with `stdio: 'ignore'`, poll for `daemon.port` (max 15s), release lock
 - [ ] 3.3 Handle stale port file: if `connectOverCDP` fails, clean up files, start fresh daemon (under lock)
 - [ ] 3.4 Guard: skip daemon auto-start if `~/.greentap/browser-data/` is empty — print "Run greentap login first"
 - [ ] 3.5 Page state check: after connecting, verify chat list grid visible; try Escape → reload → goto as escalation

--- a/openspec/changes/browser-daemon/tasks.md
+++ b/openspec/changes/browser-daemon/tasks.md
@@ -5,7 +5,7 @@
 
 ## 2. Daemon process
 
-- [ ] 2.1 Create `lib/daemon.js` — launches `launchPersistentContext` with `--remote-debugging-port=0`, writes port + PID files atomically, navigates to WA, waits for chat list
+- [ ] 2.1 Create `lib/daemon.js` — launches `launchPersistentContext` with `--remote-debugging-port=19222`, writes port + PID files atomically, navigates to WA, waits for chat list
 - [ ] 2.2 Ensure `~/.greentap/` dir is `0700`, port/PID files are `0600`
 - [ ] 2.3 Implement idle timer (15min) — reset on CDP client connect/disconnect events, clean shutdown on expiry
 - [ ] 2.4 Handle browser `disconnected` event — clean up files and exit

--- a/openspec/changes/browser-daemon/tasks.md
+++ b/openspec/changes/browser-daemon/tasks.md
@@ -1,0 +1,33 @@
+## 1. Daemon process
+
+- [ ] 1.1 Create `lib/daemon.js` — standalone Node script that launches persistent context, navigates to WA, creates Unix socket server at `~/.greentap/daemon.sock`, writes PID file
+- [ ] 1.2 Implement JSON-RPC handler: parse `{ method, params }` from socket, dispatch to command functions, return `{ result }` or `{ error }`
+- [ ] 1.3 Implement idle timer (15min) — reset on each client command, clean shutdown on expiry
+- [ ] 1.4 Handle browser disconnect event — clean up PID/socket and exit
+- [ ] 1.5 Page state reset: before each command, verify chat list grid is visible; if not, navigate to WA_URL and wait
+
+## 2. CLI client
+
+- [ ] 2.1 Create `lib/client.js` — connect to daemon socket, send JSON-RPC, receive response
+- [ ] 2.2 Implement lazy start: if socket connection fails, fork `lib/daemon.js` detached, poll for socket (max 15s), then connect
+- [ ] 2.3 Handle stale PID file: check if PID process is alive, clean up if dead
+
+## 3. Refactor command functions
+
+- [ ] 3.1 Extract command logic from `greentap.js` into reusable functions that accept a `page` parameter (instead of creating their own browser)
+- [ ] 3.2 Update `greentap.js` to route commands through daemon client instead of `withBrowser()`
+- [ ] 3.3 Keep `login` command using direct headed browser launch (bypass daemon)
+- [ ] 3.4 Make `logout` stop the daemon before clearing browser data
+
+## 4. New CLI commands
+
+- [ ] 4.1 `greentap status` — connect to daemon, print PID/uptime/idle or "No daemon running"
+- [ ] 4.2 `greentap daemon stop` — send shutdown command via socket, confirm exit
+- [ ] 4.3 `greentap daemon start` — explicit start (optional, for pre-warming)
+
+## 5. Testing
+
+- [ ] 5.1 Unit test JSON-RPC protocol (parse/serialize)
+- [ ] 5.2 Unit test stale PID detection and cleanup logic
+- [ ] 5.3 E2E test: start daemon → run command → verify result → stop daemon
+- [ ] 5.4 E2E test: idle timeout triggers clean shutdown

--- a/openspec/changes/browser-daemon/tasks.md
+++ b/openspec/changes/browser-daemon/tasks.md
@@ -1,33 +1,33 @@
-## 1. Daemon process
+## 1. Refactor command functions (prerequisite)
 
-- [ ] 1.1 Create `lib/daemon.js` — standalone Node script that launches persistent context, navigates to WA, creates Unix socket server at `~/.greentap/daemon.sock`, writes PID file
-- [ ] 1.2 Implement JSON-RPC handler: parse `{ method, params }` from socket, dispatch to command functions, return `{ result }` or `{ error }`
-- [ ] 1.3 Implement idle timer (15min) — reset on each client command, clean shutdown on expiry
-- [ ] 1.4 Handle browser disconnect event — clean up PID/socket and exit
-- [ ] 1.5 Page state reset: before each command, verify chat list grid is visible; if not, navigate to WA_URL and wait
+- [ ] 1.1 Extract command logic from `greentap.js` into reusable functions that accept a `page` parameter (instead of creating their own browser)
+- [ ] 1.2 Keep `login` command using direct headed browser launch (bypass daemon)
 
-## 2. CLI client
+## 2. Daemon process
 
-- [ ] 2.1 Create `lib/client.js` — connect to daemon socket, send JSON-RPC, receive response
-- [ ] 2.2 Implement lazy start: if socket connection fails, fork `lib/daemon.js` detached, poll for socket (max 15s), then connect
-- [ ] 2.3 Handle stale PID file: check if PID process is alive, clean up if dead
+- [ ] 2.1 Create `lib/daemon.js` — launches `launchPersistentContext` with `--remote-debugging-port=0`, writes port + PID files atomically, navigates to WA, waits for chat list
+- [ ] 2.2 Ensure `~/.greentap/` dir is `0700`, port/PID files are `0600`
+- [ ] 2.3 Implement idle timer (15min) — reset when `daemon.port` mtime changes, clean shutdown on expiry
+- [ ] 2.4 Handle browser `disconnected` event — clean up files and exit
+- [ ] 2.5 Handle SIGTERM — clean shutdown
 
-## 3. Refactor command functions
+## 3. CLI client
 
-- [ ] 3.1 Extract command logic from `greentap.js` into reusable functions that accept a `page` parameter (instead of creating their own browser)
-- [ ] 3.2 Update `greentap.js` to route commands through daemon client instead of `withBrowser()`
-- [ ] 3.3 Keep `login` command using direct headed browser launch (bypass daemon)
-- [ ] 3.4 Make `logout` stop the daemon before clearing browser data
+- [ ] 3.1 Create `lib/client.js` — read `daemon.port`, `connectOverCDP`, return `{ browser, context, page }`; on disconnect call `browser.close()` (doesn't kill Chrome)
+- [ ] 3.2 Implement lazy start with exclusive lock: acquire `daemon.lock`, fork `lib/daemon.js` detached with `stdio: 'ignore'`, poll for `daemon.port` (max 15s), release lock
+- [ ] 3.3 Handle stale port file: if `connectOverCDP` fails, clean up files, start fresh daemon (under lock)
+- [ ] 3.4 Guard: skip daemon auto-start if `~/.greentap/browser-data/` is empty — print "Run greentap login first"
+- [ ] 3.5 Page state check: after connecting, verify chat list grid visible; try Escape → reload → goto as escalation
 
-## 4. New CLI commands
+## 4. Wire up CLI
 
-- [ ] 4.1 `greentap status` — connect to daemon, print PID/uptime/idle or "No daemon running"
-- [ ] 4.2 `greentap daemon stop` — send shutdown command via socket, confirm exit
-- [ ] 4.3 `greentap daemon start` — explicit start (optional, for pre-warming)
+- [ ] 4.1 Update `greentap.js` to route commands through `lib/client.js` instead of `withBrowser()`
+- [ ] 4.2 Make `logout` send SIGTERM to daemon PID before clearing browser data
+- [ ] 4.3 `greentap status` — read PID/port files, check process alive, print info or "No daemon running"
+- [ ] 4.4 `greentap daemon stop` — send SIGTERM to daemon PID, wait for exit
 
 ## 5. Testing
 
-- [ ] 5.1 Unit test JSON-RPC protocol (parse/serialize)
-- [ ] 5.2 Unit test stale PID detection and cleanup logic
-- [ ] 5.3 E2E test: start daemon → run command → verify result → stop daemon
-- [ ] 5.4 E2E test: idle timeout triggers clean shutdown
+- [ ] 5.1 Unit test client connection logic (stale port, missing port, lock)
+- [ ] 5.2 E2E test: start daemon → connect → verify page accessible → stop daemon
+- [ ] 5.3 E2E test: idle timeout triggers clean shutdown


### PR DESCRIPTION
## Summary

OpenSpec proposal for Phase 3 — persistent browser daemon to reduce per-command latency from 3-5s to ~200ms.

- **proposal.md** — Why: 3-5s startup tax per command, daemon keeps Chrome alive
- **design.md** — How: Unix socket IPC, JSON-RPC, lazy start, 15min auto-shutdown
- **specs/** — browser-daemon, daemon-lifecycle, browser-wait (modified)
- **tasks.md** — 17 tasks across 5 groups

### Key decisions
- Unix domain socket (not WebSocket) — simpler, no deps, localhost only
- Lazy start: first command auto-launches daemon
- 15min idle timeout auto-shutdown
- `login` bypasses daemon (needs headed browser)
- Page state reset between commands

### Review checklist
- [ ] Proposal scope is right
- [ ] Design decisions make sense
- [ ] Specs are testable and complete
- [ ] Tasks are ordered and sized correctly