### PR TITLE
fix: use exact name matching in chat navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,10 @@ drafts.md
 summary_stats.txt
 *_msgs.json
 *_stats.txt
+
+# Skills infrastructure (agent-deck, skills.sh)
+.agent/
+.agents/
+.worktrees/
+skills/
+skills-lock.json

--- a/greentap.js
+++ b/greentap.js
@@ -100,7 +100,7 @@ async function cmdRead(chatName, json, scroll) {
 }
 
 async function cmdSend(chatName, message) {
-  await withDaemon((page) => commands.send(page, chatName, message));
+  await withDaemon((page, localeConfig) => commands.send(page, chatName, message, localeConfig));
 }
 
 async function cmdSearch(query, json) {
@@ -120,7 +120,7 @@ async function cmdSearch(query, json) {
 }
 
 async function cmdSnapshot(scope, chatName) {
-  const result = await withDaemon((page) => commands.snapshot(page, scope, chatName));
+  const result = await withDaemon((page, localeConfig) => commands.snapshot(page, scope, chatName, localeConfig));
   console.log(result);
 }
 

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -22,37 +22,53 @@ export async function waitForMessagePanel(page) {
   await page.getByRole("contentinfo").getByRole("textbox").waitFor({ timeout: 10000 });
 }
 
-export async function navigateToChat(page, chatName) {
-  // Try visible chat list first
+export async function navigateToChat(page, chatName, localeConfig) {
+  // Try visible chat list first — parse aria for exact name match
   const chatGrid = page.getByRole("grid").first();
-  const row = chatGrid.getByRole("row").filter({ hasText: chatName }).first();
-  if (await row.isVisible()) {
-    await humanDelay(200, 500);
-    await row.click();
-    await waitForMessagePanel(page);
-    return;
+  if (await chatGrid.isVisible().catch(() => false)) {
+    const gridAria = await chatGrid.ariaSnapshot();
+    const chats = parseChatList(gridAria, localeConfig);
+    const exactMatch = chats.find((c) => c.name === chatName);
+    if (exactMatch) {
+      // Use the full gridcell label (name+time) for precise row selection
+      const row = chatGrid.getByRole("row").filter({
+        has: page.getByRole("gridcell", { name: exactMatch._gridcellLabel, exact: true }),
+      }).first();
+      await humanDelay(200, 500);
+      await row.click();
+      await waitForMessagePanel(page);
+      return;
+    }
   }
 
-  // Fallback: search (handles archived chats)
-  // Search box is the first textbox (in sidebar)
+  // Fallback: search (handles archived chats and chats not in visible list)
   const searchBox = page.getByRole("textbox").first();
   await searchBox.click();
   await humanDelay(300, 600);
   await page.keyboard.type(chatName, { delay: 30 });
 
   try {
-    // Wait for search results grid — it replaces the chat list grid.
-    // Wait for a row containing the chat name to appear.
     await page.getByRole("grid").first().getByRole("row").filter({ hasText: chatName }).first().waitFor({ timeout: 5000 });
   } catch {
-    // Clean up search and throw
     await page.keyboard.press("Escape");
     await page.keyboard.press("Escape");
     throw new Error(`Chat "${chatName}" not found`);
   }
 
+  // Parse search results for exact name match
+  const searchAria = await page.locator(":root").ariaSnapshot();
+  const searchResults = parseSearchResults(searchAria, localeConfig);
+  const searchMatch = searchResults.find((c) => c.name === chatName);
+  if (!searchMatch) {
+    await page.keyboard.press("Escape");
+    await page.keyboard.press("Escape");
+    throw new Error(`Chat "${chatName}" not found (no exact match in search results)`);
+  }
+
   const searchGrid = page.getByRole("grid").first();
-  const searchRow = searchGrid.getByRole("row").filter({ hasText: chatName }).first();
+  const searchRow = searchGrid.getByRole("row").filter({
+    has: page.getByRole("gridcell", { name: searchMatch._gridcellLabel, exact: true }),
+  }).first();
   if (!(await searchRow.isVisible())) {
     await page.keyboard.press("Escape");
     await page.keyboard.press("Escape");
@@ -190,8 +206,8 @@ async function scrollAndCollect(page) {
   });
 }
 
-export async function read(page, chatName, { scroll = false } = {}) {
-  await navigateToChat(page, chatName);
+export async function read(page, chatName, { scroll = false, localeConfig } = {}) {
+  await navigateToChat(page, chatName, localeConfig);
   if (scroll) {
     return scrollAndCollect(page);
   }
@@ -199,14 +215,14 @@ export async function read(page, chatName, { scroll = false } = {}) {
   return parseMessages(aria);
 }
 
-export async function send(page, chatName, message) {
-  await navigateToChat(page, chatName);
+export async function send(page, chatName, message, localeConfig) {
+  await navigateToChat(page, chatName, localeConfig);
 
-  // Verify correct chat opened — find the header button that contains the chat name
+  // Verify correct chat opened — find the header button that matches the chat name exactly
   const aria = await page.locator(":root").ariaSnapshot();
   const headerButtons = [...aria.matchAll(/button "([^"]+)"/g)].map((m) => m[1]);
   const chatHeader = headerButtons.find((label) =>
-    label.toLowerCase().includes(chatName.toLowerCase())
+    label === chatName
   );
   if (!chatHeader) {
     throw new Error(`Wrong chat opened. Expected "${chatName}" but no matching header button found.`);
@@ -275,9 +291,9 @@ export async function search(page, query, localeConfig) {
   return parseSearchResults(aria, localeConfig);
 }
 
-export async function snapshot(page, scope, chatName) {
+export async function snapshot(page, scope, chatName, localeConfig) {
   if (chatName) {
-    await navigateToChat(page, chatName);
+    await navigateToChat(page, chatName, localeConfig);
   }
 
   const rootAria = await page.locator(":root").ariaSnapshot();

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -65,7 +65,7 @@ export function parseChatList(ariaText, localeConfig) {
     const unreadMatch = rowBody.match(/- gridcell "[^"]*": "(\d+)"/);
     const unread = unreadMatch ? parseInt(unreadMatch[1], 10) : 0;
 
-    chats.push({ name, time, lastMessage, unread: unread > 0, unreadCount: unread });
+    chats.push({ name, time, lastMessage, unread: unread > 0, unreadCount: unread, _gridcellLabel: nameTimeStr });
   }
 
   return chats;


### PR DESCRIPTION
## Summary

- `navigateToChat` used Playwright's `hasText` (substring match) which could open the wrong chat — e.g. "Marco" matching "Marco Polo"
- Now parses aria snapshots for exact name comparison, using the full gridcell label for precise row selection
- Fixes `send`'s header verification to use exact match instead of case-insensitive `includes`
- Also adds `_gridcellLabel` to parsed chat objects for precise Playwright row targeting
- Includes minor chore: gitignore entries for skills infrastructure dirs

## Test plan

- [x] All 53 unit tests pass (`npm test`)
- [ ] Manual: `greentap send "Marco" "test"` does not accidentally open "Marco Polo" chat
- [ ] Manual: `greentap read "Marco"` opens correct chat when "Marco Polo" also exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)