### PR TITLE
feat: click load-more button when scroll hits top

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -105,6 +105,35 @@ async function findScrollContainer(page) {
   });
 }
 
+async function findLoadMoreButton(page) {
+  // The "load more" button appears at the top of the message area when older
+  // messages are available on the phone. It's a plain <button> with long
+  // locale-dependent text (e.g. "Clicca qui per vedere i messaggi meno recenti
+  // del tuo telefono." in Italian). Structurally: inside the scroll container,
+  // before any [role="row"], not inside a row/grid/banner.
+  return page.evaluate(() => {
+    const scrollEl = document.querySelector('[data-greentap-scroll="1"]');
+    if (!scrollEl) return false;
+
+    const firstRow = scrollEl.querySelector('[role="row"]');
+    const buttons = scrollEl.querySelectorAll("button");
+
+    for (const btn of buttons) {
+      if (btn.closest('[role="row"]') || btn.closest('[role="grid"]') || btn.closest('[role="banner"]')) continue;
+      // Must appear before the first message row in DOM order
+      if (firstRow && !(btn.compareDocumentPosition(firstRow) & Node.DOCUMENT_POSITION_FOLLOWING)) continue;
+      const text = btn.textContent?.trim() || "";
+      // The load-more text is always >30 chars; filters out "Scroll to bottom",
+      // "end-to-end encrypted", and icon-only buttons
+      if (text.length > 30) {
+        btn.click();
+        return true;
+      }
+    }
+    return false;
+  });
+}
+
 async function scrollAndCollect(page) {
   const found = await findScrollContainer(page);
   if (!found) throw new Error("Could not find scrollable message container");
@@ -131,6 +160,14 @@ async function scrollAndCollect(page) {
     if (firstKey && firstKey === lastFirstKey) {
       stableCount++;
       if (stableCount >= 3) {
+        // Before giving up, try clicking the "load more" button
+        const clicked = await findLoadMoreButton(page);
+        if (clicked) {
+          await new Promise((r) => setTimeout(r, 1000));
+          stableCount = 0;
+          lastFirstKey = null;
+          continue;
+        }
         exitReason = "stable";
         break;
       }


### PR DESCRIPTION
## Summary

- When `read --scroll` scrolls up to collect message history, WhatsApp sometimes shows a "load more messages from phone" button instead of auto-loading
- New `findLoadMoreButton` detects this button by DOM position (before first row, inside scroll container) and text length (>30 chars)
- Detection is locale-agnostic — no hardcoded button labels
- Clicks the button, waits 1s, then resumes scrolling

## Test plan

- [x] All 53 unit tests pass (`npm test`)
- [ ] Manual: `greentap read --scroll <chat>` on a chat with many messages — verify load-more button is clicked when present
- [ ] Manual: verify scrolling still works normally when no load-more button exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)