### PR TITLE
fix: strip unread badge prefix from chat names

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -9,6 +9,89 @@
 
 import { buildTimePattern } from "./locale.js";
 
+/**
+ * Regex to strip unread badge prefix from chat name gridcell labels.
+ * WhatsApp prepends "N unread message(s)" (locale-dependent) to the inner
+ * gridcell label when a chat has unread messages. This contaminates the
+ * extracted chat name, breaking downstream commands (e.g. `read`) that
+ * match by name.
+ *
+ * Covers: English, Italian, French, German, Spanish, Portuguese, Dutch,
+ * Polish, Turkish, Swedish, Danish, Norwegian, Finnish, Czech, Romanian,
+ * Ukrainian, Hungarian, Croatian, Slovak, Bulgarian, Indonesian, Malay,
+ * Catalan, Russian, Arabic, Hindi, Thai, Vietnamese, Japanese, Korean,
+ * Chinese (Simplified/Traditional).
+ */
+const UNREAD_BADGE_PREFIX = new RegExp(
+  "^\\d+\\s+(" +
+    // English
+    "unread messages?|" +
+    // Italian
+    "messaggi non letti|messaggio non letto|" +
+    // French
+    "messages? non lus?|" +
+    // German
+    "ungelesene Nachrichten?|" +
+    // Spanish
+    "mensajes? no leídos?|mensajes? sin leer|" +
+    // Portuguese
+    "mensagens? não lidas?|" +
+    // Dutch
+    "ongelezen berichten?|" +
+    // Polish
+    "nieprzeczytane wiadomości|nieprzeczytanych wiadomości|" +
+    // Turkish
+    "okunmamış mesaj|" +
+    // Swedish
+    "olästa meddelanden?|" +
+    // Danish
+    "ulæste beskeder?|" +
+    // Norwegian
+    "uleste meldinger?|" +
+    // Finnish
+    "lukematonta? viestiä?|" +
+    // Czech
+    "nepřečtené zprávy?|nepřečtených zpráv|" +
+    // Romanian
+    "mesaje necitite|mesaj necitit|" +
+    // Ukrainian
+    "непрочитаних повідомлень|непрочитане повідомлення|" +
+    // Hungarian
+    "olvasatlan üzenet(?:ek)?|" +
+    // Croatian
+    "nepročitanih poruka|nepročitana poruka|" +
+    // Slovak
+    "neprečítané správy?|neprečítaných správ|" +
+    // Bulgarian
+    "непрочетени съобщения|непрочетено съобщение|" +
+    // Indonesian
+    "pesan belum dibaca|" +
+    // Malay
+    "mesej belum dibaca|" +
+    // Catalan
+    "missatges? no llegits?|" +
+    // Russian
+    "непрочитанных сообщений|непрочитанное сообщение|" +
+    // Arabic
+    "رسائل غير مقروءة|رسالة غير مقروءة|" +
+    // Hindi
+    "अपठित संदेश|" +
+    // Thai
+    "ข้อความที่ยังไม่ได้อ่าน|" +
+    // Vietnamese
+    "tin nhắn chưa đọc|" +
+    // Japanese
+    "件の未読メッセージ|" +
+    // Korean
+    "개의 읽지 않은 메시지|" +
+    // Chinese (Simplified)
+    "条未读消息|" +
+    // Chinese (Traditional)
+    "則未讀訊息" +
+  ")\\s+",
+  "i"
+);
+
 // Fallback locale config for unit tests with Italian fixtures
 const ITALIAN_FALLBACK = {
   dayNames: ["lunedì", "martedì", "mercoledì", "giovedì", "venerdì", "sabato", "domenica"],
@@ -55,6 +138,9 @@ export function parseChatList(ariaText, localeConfig) {
       time = "";
       name = nameTimeStr.trim();
     }
+
+    // Strip unread badge prefix (e.g. "3 unread messages ", "1 messaggio non letto ")
+    name = name.replace(UNREAD_BADGE_PREFIX, "");
 
     // Extract last message from text: nodes (first one after the name gridcell)
     const textNodes = [...rowBody.matchAll(/- text: (.+)/g)];

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -72,6 +72,66 @@ describe("parseChatList", () => {
   it("returns empty array for aria without chat grid", () => {
     assert.deepEqual(parseChatList('- document:\n  - heading "Nothing" [level=1]'), []);
   });
+
+  it("strips unread badge prefix from chat names (English)", () => {
+    const aria = `- grid "Chat list":
+    - row "3 unread messages WE 1 maggio 2025 17:36 Last msg 3 unread messages":
+      - gridcell "3 unread messages WE 1 maggio 2025 17:36 Last msg 3 unread messages":
+        - img
+        - gridcell "3 unread messages WE 1 maggio 2025 17:36"
+        - text: Last msg
+        - gridcell "3 unread messages": "3"
+  - text: end`;
+    const chats = parseChatList(aria);
+    assert.equal(chats.length, 1);
+    assert.equal(chats[0].name, "WE 1 maggio 2025");
+    assert.equal(chats[0].unreadCount, 3);
+  });
+
+  it("strips unread badge prefix from chat names (Italian)", () => {
+    const aria = `- grid "Lista delle chat":
+    - row "1 messaggio non letto Test Chat 14:00 Ciao 1 messaggio non letto":
+      - gridcell "1 messaggio non letto Test Chat 14:00 Ciao 1 messaggio non letto":
+        - img
+        - gridcell "1 messaggio non letto Test Chat 14:00"
+        - text: Ciao
+        - gridcell "1 messaggio non letto": "1"
+  - text: end`;
+    const chats = parseChatList(aria);
+    assert.equal(chats.length, 1);
+    assert.equal(chats[0].name, "Test Chat");
+    assert.equal(chats[0].unreadCount, 1);
+  });
+
+  it("strips unread badge prefix from chat names (French)", () => {
+    const aria = `- grid "Liste des discussions":
+    - row "5 messages non lus Mon Groupe 09:15 Salut 5 messages non lus":
+      - gridcell "5 messages non lus Mon Groupe 09:15 Salut 5 messages non lus":
+        - img
+        - gridcell "5 messages non lus Mon Groupe 09:15"
+        - text: Salut
+        - gridcell "5 messages non lus": "5"
+  - text: end`;
+    const chats = parseChatList(aria);
+    assert.equal(chats.length, 1);
+    assert.equal(chats[0].name, "Mon Groupe");
+    assert.equal(chats[0].unreadCount, 5);
+  });
+
+  it("strips Italian plural unread badge prefix", () => {
+    const aria = `- grid "Lista delle chat":
+    - row "61 messaggi non letti Sport Club 17:28 Msg Chat silenziata messaggio con menzione 61 messaggi non letti":
+      - gridcell "61 messaggi non letti Sport Club 17:28 Msg Chat silenziata messaggio con menzione 61 messaggi non letti":
+        - img
+        - gridcell "61 messaggi non letti Sport Club 17:28"
+        - text: Msg
+        - gridcell "Chat silenziata messaggio con menzione 61 messaggi non letti": "61"
+  - text: end`;
+    const chats = parseChatList(aria);
+    assert.equal(chats.length, 1);
+    assert.equal(chats[0].name, "Sport Club");
+    assert.equal(chats[0].unreadCount, 61);
+  });
 });
 
 describe("printChats", () => {


### PR DESCRIPTION
## Summary

- When chats have unread messages, WhatsApp prepends locale-dependent text (e.g. "3 unread messages", "1 messaggio non letto") to the inner gridcell label
- This contaminated the extracted chat name, breaking `read` and other commands that match by name
- Adds `UNREAD_BADGE_PREFIX` regex that strips the prefix for 30+ WhatsApp locales (English, Italian, French, German, Spanish, Portuguese, Dutch, Polish, Russian, Arabic, Chinese, Japanese, Korean, and more)
- Applied as a single `name.replace()` after name extraction in `parseChatList`

## Test plan

- [x] All 57 unit tests pass (53 existing + 4 new)
- [x] New tests cover: English, Italian singular, Italian plural, French unread badge prefixes
- [ ] Manual: `greentap chats --json` with unread chats — verify names are clean
- [ ] Manual: `greentap read <chat>` on a chat that previously had polluted name

🤖 Generated with [Claude Code](https://claude.com/claude-code)