### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "greentap",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "CLI driver for WhatsApp Web via Playwright",
   "main": "greentap.js",
   "bin": {


### PR DESCRIPTION
Match release tag v0.2.0