### PR TITLE
feat: add poll-results command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ node greentap.js logout              # Clear session data
 node greentap.js chats [--json]      # List all chats
 node greentap.js unread [--json]     # List unread chats
 node greentap.js read <chat> [--json] [--scroll] # Read messages from a chat
+node greentap.js poll-results <chat> [--json]  # Get most recent poll question + vote counts
 node greentap.js send <chat> <msg>   # Send a message
 node greentap.js search <q> [--json] # Search chats
 node greentap.js snapshot [SCOPE]    # Dump aria snapshot (full|chats|messages|compose)

--- a/greentap.js
+++ b/greentap.js
@@ -103,6 +103,29 @@ async function cmdSend(chatName, message, index) {
   await withDaemon((page, localeConfig) => commands.send(page, chatName, message, localeConfig, index));
 }
 
+async function cmdPollResults(chatName, json, index) {
+  const result = await withDaemon((page, localeConfig) => commands.pollResults(page, chatName, { localeConfig, index }));
+  if (result === null) {
+    if (json) {
+      console.log(JSON.stringify(null));
+    } else {
+      console.log("No poll found in this chat.");
+    }
+    return;
+  }
+  if (json) {
+    console.log(JSON.stringify(result));
+  } else {
+    console.log(`Poll: ${result.question}`);
+    if (result.time) console.log(`Time: ${result.time}`);
+    if (result.sender) console.log(`Sender: ${result.sender}`);
+    console.log("Options:");
+    for (const opt of result.options) {
+      console.log(`  ${opt.label}: ${opt.votes} votes`);
+    }
+  }
+}
+
 async function cmdSearch(query, json) {
   const result = await withDaemon((page, localeConfig) => commands.search(page, query, localeConfig));
   if (json) {
@@ -191,6 +214,22 @@ try {
       await cmdSend(sendArgs[0], sendArgs.slice(1).join(" "), sendIndex);
       break;
     }
+    case "poll-results": {
+      const prIndexIdx = args.indexOf("--index");
+      const prIndex = prIndexIdx >= 0 ? parseInt(args[prIndexIdx + 1], 10) : undefined;
+      const prChat = args.slice(1).filter((a, relI) => {
+        const absI = relI + 1;
+        if (a === "--json" || a === "--index") return false;
+        if (prIndexIdx >= 0 && absI === prIndexIdx + 1) return false;
+        return true;
+      })[0];
+      if (!prChat) {
+        console.error("Usage: greentap poll-results <chat> [--json] [--index N]");
+        process.exit(1);
+      }
+      await cmdPollResults(prChat, args.includes("--json"), prIndex);
+      break;
+    }
     case "search": {
       const searchQuery = args.slice(1).filter((a) => a !== "--json").join(" ");
       if (!searchQuery) {
@@ -224,16 +263,17 @@ try {
       console.log(`Usage: greentap <command> [options]
 
 Commands:
-  login                                   Open browser for QR scan
-  logout                                  Clear session data
-  chats [--json]                          List all chats
-  unread [--json]                         List unread chats
+  login                                        Open browser for QR scan
+  logout                                       Clear session data
+  chats [--json]                               List all chats
+  unread [--json]                              List unread chats
   read <chat> [--json] [--scroll] [--index N]  Read messages from a chat
-  send <chat> <message> [--index N]       Send a message to a chat
-  search <query> [--json]                 Search chats
-  snapshot [SCOPE] [--chat NAME]          Dump aria snapshot (full|chats|messages|compose)
-  status                                  Show daemon status
-  daemon stop                             Stop the daemon
+  send <chat> <message> [--index N]            Send a message to a chat
+  poll-results <chat> [--json] [--index N]     Get most recent poll results
+  search <query> [--json]                      Search chats
+  snapshot [SCOPE] [--chat NAME]               Dump aria snapshot (full|chats|messages|compose)
+  status                                       Show daemon status
+  daemon stop                                  Stop the daemon
 
   --index N  Select the Nth match when multiple chats share the same name (1-based)`);
   }

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -6,7 +6,7 @@
  * instead of locale-specific labels.
  */
 
-import { parseChatList, parseMessages, parseSearchResults } from "./parser.js";
+import { parseChatList, parseMessages, parseSearchResults, parsePollMessages } from "./parser.js";
 
 function humanDelay(min = 200, max = 500) {
   const ms = Math.floor(Math.random() * (max - min + 1)) + min;
@@ -315,6 +315,73 @@ export async function send(page, chatName, message, localeConfig, index) {
   }
 
   console.log(`Sent to ${chatName}.`);
+}
+
+export async function pollResults(page, chatName, { localeConfig, index } = {}) {
+  await navigateToChat(page, chatName, localeConfig, index);
+
+  const found = await findScrollContainer(page);
+  if (!found) throw new Error("Could not find scrollable message container");
+
+  let polls = [];
+  let stableCount = 0;
+  let lastFirstKey = null;
+  const startTime = Date.now();
+  const MAX_ITERATIONS = 50;
+  const TIMEOUT_MS = 30000;
+
+  for (let i = 0; i < MAX_ITERATIONS; i++) {
+    if (Date.now() - startTime > TIMEOUT_MS) break;
+
+    const aria = await page.locator(":root").ariaSnapshot();
+    const found_polls = parsePollMessages(aria);
+    if (found_polls.length > 0) {
+      // Keep scanning up for older polls in case multiple are visible;
+      // after the first batch, track stability and return when nothing new appears.
+      polls = found_polls;
+    }
+
+    // Check scroll stability (same first message = can't go further)
+    const msgs = parseMessages(aria);
+    const firstKey = msgs.length > 0 ? dedupKey(msgs[0]) : null;
+    if (firstKey && firstKey === lastFirstKey) {
+      stableCount++;
+      if (stableCount >= 3) {
+        const clicked = await findLoadMoreButton(page);
+        if (clicked) {
+          await new Promise((r) => setTimeout(r, 1000));
+          stableCount = 0;
+          lastFirstKey = null;
+          continue;
+        }
+        break;
+      }
+    } else {
+      stableCount = 1;
+      lastFirstKey = firstKey;
+    }
+
+    // If we already have polls and we've scrolled past the visible area
+    // once (i > 0), the most recent poll is already captured — stop early
+    // to avoid scanning the entire history unnecessarily.
+    if (polls.length > 0 && i > 0) break;
+
+    // Scroll up to look for more recent polls further back in history
+    await page.evaluate(() => {
+      const el = document.querySelector("[data-greentap-scroll=\"1\"]");
+      if (el) el.scrollTop = 0;
+    });
+    await new Promise((r) => setTimeout(r, 500));
+  }
+
+  // Scroll back to bottom
+  await page.evaluate(() => {
+    const el = document.querySelector("[data-greentap-scroll=\"1\"]");
+    if (el) el.scrollTop = el.scrollHeight;
+  });
+
+  // Return the most recent poll (last in list = lowest in snapshot = most recent)
+  return polls.length > 0 ? polls[polls.length - 1] : null;
 }
 
 export async function search(page, query, localeConfig) {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -362,6 +362,104 @@ export function printMessages(messages) {
   }
 }
 
+// Locale-specific markers used inside poll rows.
+// "Select an option" prompt that follows the question text in the poll row body.
+const POLL_SELECT_MARKERS = [
+  "Seleziona un'opzione", // Italian
+  "Select an option",      // English
+  "Sélectionner une option", // French
+  "Seleccionar una opción",  // Spanish
+  "Selecionar uma opção",    // Portuguese
+];
+
+/**
+ * Parse WhatsApp native poll messages from an aria snapshot.
+ *
+ * Poll rows are identified by the presence of checkbox elements in the row body.
+ * Each checkbox has the form "OptionName N votes_word" (locale-dependent).
+ *
+ * Returns an array of poll objects, ordered as they appear in the snapshot
+ * (typically oldest-first when reading top-to-bottom).
+ *
+ * @param {string} ariaText
+ * @returns {Array<{question: string, options: Array<{label: string, votes: number}>, time: string, sender: string}>}
+ */
+export function parsePollMessages(ariaText) {
+  if (!ariaText) return [];
+
+  const polls = [];
+  const lines = ariaText.split("\n");
+
+  for (let i = 0; i < lines.length; i++) {
+    const rowMatch = lines[i].match(/^  - (?:')?row "(.+?)"(?:')?:/);
+    if (!rowMatch) continue;
+
+    const rowLabel = rowMatch[1];
+
+    // Collect row body (lines indented more than 2 spaces)
+    const bodyLines = [];
+    for (let j = i + 1; j < lines.length; j++) {
+      if (/^    /.test(lines[j])) bodyLines.push(lines[j]);
+      else break;
+    }
+    const rowBody = bodyLines.join("\n");
+
+    // Poll rows contain checkboxes — regular messages never have checkboxes
+    if (!rowBody.includes("- checkbox \"")) continue;
+
+    // Extract all text nodes from the row body
+    const textNodes = [...rowBody.matchAll(/- text: (.+)/g)].map((m) => m[1].trim());
+
+    // Question: in the text node that contains the "select an option" marker
+    let question = null;
+    for (const textNode of textNodes) {
+      for (const marker of POLL_SELECT_MARKERS) {
+        if (textNode.includes(marker)) {
+          question = textNode.slice(0, textNode.indexOf(marker)).trim();
+          break;
+        }
+      }
+      if (question !== null) break;
+    }
+
+    // Fallback: extract question from row label
+    // Row label pattern: "... TIME QUESTION [Opzioni più votate|Most voted options|...]: ..."
+    if (question === null) {
+      // Try to find the question between the time and the "voted options" phrase
+      const labelMatch = rowLabel.match(/\d{1,2}:\d{2}\s+(.+?)\s+(?:Opzioni più votate|Most voted options|Options les plus)/);
+      if (labelMatch) question = labelMatch[1].trim();
+    }
+
+    // Extract options and vote counts from checkbox labels.
+    // Checkbox label format: "OptionName N voti" (IT) / "OptionName N votes" (EN) etc.
+    // The vote count is always the last number before the trailing word.
+    const checkboxes = [...rowBody.matchAll(/- checkbox "(.+?)"/g)];
+    const options = [];
+    for (const cb of checkboxes) {
+      const cbLabel = cb[1];
+      // Match: everything up to last run of digits + optional trailing word
+      const countMatch = cbLabel.match(/^(.+?)\s+(\d+)(?:\s+\w+)?$/);
+      if (countMatch) {
+        options.push({ label: countMatch[1].trim(), votes: parseInt(countMatch[2], 10) });
+      } else {
+        options.push({ label: cbLabel, votes: 0 });
+      }
+    }
+
+    // Extract time
+    const time = textNodes.find((t) => /^\d{1,2}:\d{2}$/.test(t)) || "";
+
+    // Extract sender from the button at the top of the row body
+    // Pattern: button "SenderName" with nested text
+    const senderBtnMatch = rowBody.match(/- button "([^"]+)":\n\s+- text:/);
+    const sender = senderBtnMatch ? senderBtnMatch[1].trim() : "";
+
+    polls.push({ question: question || "(unknown)", options, time, sender });
+  }
+
+  return polls;
+}
+
 /**
  * Parse search results from a WhatsApp Web aria snapshot.
  * Search results use a separate grid with the same row/gridcell structure as the chat list.

--- a/test/fixtures/poll-aria.txt
+++ b/test/fixtures/poll-aria.txt
@@ -1,0 +1,73 @@
+- document:
+  - banner:
+    - button "Chat" [pressed]: "0"
+    - button "Aggiornamenti nello stato"
+    - button "Canali"
+    - button "Community"
+    - button "File multimediali"
+    - button "Tu":
+      - img
+  - banner:
+    - banner:
+      - heading "WhatsApp" [level=2]:
+        - img "wa-wordmark-refreshed"
+      - button "Nuova chat"
+      - button "Menu"
+  - textbox "Cerca o avvia una nuova chat"
+  - tablist "chat-list-filters":
+    - tab "Tutte"
+    - tab "‎Non lette 0"
+    - tab "‎Preferiti"
+    - tab "‎Gruppi 0"
+    - tab "Nuova lista"
+  - grid "Lista delle chat":
+    - row "Sport Club 14:30 ~ Roberto M. : A domani":
+      - gridcell "Sport Club 14:30 ~ Roberto M. : A domani":
+        - img
+        - gridcell "Sport Club 14:30"
+        - text: "~ Roberto M. : A domani"
+        - gridcell
+  - banner:
+    - button "Dettagli profilo":
+      - img
+    - button "Sport Club clicca qui per info gruppo"
+    - button "Cerca"
+    - button "Menu"
+  - text: I tuoi messaggi personali sono
+  - button "crittografati end-to-end"
+  - text: .
+  - text: 18/03/2026
+  - button "Apri dettagli chat di Roberto Marini": R
+  - row "Roberto Marini Ciao ragazzi, ci vediamo stasera? 13:10":
+    - text: Roberto Marini
+    - text: Ciao ragazzi, ci vediamo stasera? 13:10
+  - button "Apri dettagli chat di Elena Conti": E
+  - row "Elena Conti Sì, ci sono! 13:25 Reazioni 👍 3 in totale. Visualizza reazioni":
+    - text: Elena Conti
+    - text: Sì, ci sono! 13:25
+    - button "Reazioni 👍 3 in totale. Visualizza reazioni":
+      - img "👍"
+      - text: "3"
+  - button "Apri dettagli chat di Roberto Marini": R
+  - row "Sondaggio inviato da Roberto Marini 14:00 Partita mercoledì 18/03 21h-22h30 Opzioni più votate: Presente: 8, Assente: 2.":
+    - button "Roberto Marini":
+      - text: Roberto Marini
+    - text: Partita mercoledì 18/03 21h-22h30 Seleziona un'opzione
+    - checkbox "Presente 8 voti"
+    - text: Presente
+    - button "8"
+    - checkbox "Assente 2 voti"
+    - text: Assente
+    - button "2"
+    - text: 14:00
+    - button "Visualizza voti"
+  - row "Roberto Marini A domani allora! 14:30":
+    - text: Roberto Marini
+    - text: A domani allora! 14:30
+  - contentinfo:
+    - button "Allega"
+    - button "Emoji, GIF, Sticker"
+    - textbox "Digita un messaggio per il gruppo Sport Club":
+      - paragraph
+    - button "Messaggio vocale":
+      - button "Messaggio vocale"

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "fs";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
-import { parseChatList, printChats, parseMessages, printMessages, parseSearchResults } from "../lib/parser.js";
+import { parseChatList, printChats, parseMessages, printMessages, parseSearchResults, parsePollMessages } from "../lib/parser.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const FIXTURES = join(__dirname, "fixtures");
@@ -280,5 +280,65 @@ describe("parseSearchResults", () => {
 
   it("returns empty array for aria without search grid", () => {
     assert.deepEqual(parseSearchResults('- document:\n  - heading "Nothing" [level=1]'), []);
+  });
+});
+
+describe("parsePollMessages", () => {
+  it("parses poll from fixture", () => {
+    const aria = loadFixture("poll-aria.txt");
+    const polls = parsePollMessages(aria);
+
+    assert.ok(polls.length >= 1, "should find at least one poll");
+  });
+
+  it("extracts poll question", () => {
+    const aria = loadFixture("poll-aria.txt");
+    const polls = parsePollMessages(aria);
+    const poll = polls[0];
+
+    assert.ok(poll.question.length > 0, "question should not be empty");
+    assert.ok(poll.question.includes("Partita"), "question should contain poll title");
+  });
+
+  it("extracts poll options with vote counts", () => {
+    const aria = loadFixture("poll-aria.txt");
+    const polls = parsePollMessages(aria);
+    const poll = polls[0];
+
+    assert.equal(poll.options.length, 2, "should have 2 options");
+
+    const presente = poll.options.find((o) => o.label === "Presente");
+    assert.ok(presente, "should have Presente option");
+    assert.equal(presente.votes, 8, "Presente should have 8 votes");
+
+    const assente = poll.options.find((o) => o.label === "Assente");
+    assert.ok(assente, "should have Assente option");
+    assert.equal(assente.votes, 2, "Assente should have 2 votes");
+  });
+
+  it("extracts poll time", () => {
+    const aria = loadFixture("poll-aria.txt");
+    const polls = parsePollMessages(aria);
+    const poll = polls[0];
+
+    assert.equal(poll.time, "14:00");
+  });
+
+  it("extracts poll sender", () => {
+    const aria = loadFixture("poll-aria.txt");
+    const polls = parsePollMessages(aria);
+    const poll = polls[0];
+
+    assert.ok(poll.sender.includes("Roberto"), "sender should be Roberto Marini");
+  });
+
+  it("returns empty array for snapshot without polls", () => {
+    const aria = loadFixture("main-aria.txt");
+    const polls = parsePollMessages(aria);
+    assert.deepEqual(polls, []);
+  });
+
+  it("returns empty array for empty input", () => {
+    assert.deepEqual(parsePollMessages(""), []);
   });
 });


### PR DESCRIPTION
## Summary

- New command `poll-results <chat> [--json] [--index N]` returns the most recent WhatsApp native poll from a chat
- Returns: `{ question, options: [{label, votes}], time, sender }` as JSON
- Locale-agnostic detection: polls identified by `checkbox` ARIA elements (present only in poll rows), not locale-specific strings
- Scrolls up through chat history to find the most recent poll; stops after first hit

## Implementation

- `parsePollMessages(ariaText)` added to `lib/parser.js`
- `pollResults()` added to `lib/commands.js`, reuses scroll/dedup infrastructure
- `poll-results` case wired in `greentap.js`
- 7 unit tests + `test/fixtures/poll-aria.txt` fixture (fake data: Roberto Marini, Elena Conti)

## Test plan

- [ ] `npm test` — 74 tests, all pass
- [ ] `greentap poll-results "Foot ça repart" --json` → returns 01/04 poll: Présent 10, Absent 2
- [ ] `greentap poll-results "Calcetto Lyon" --json` → returns null (group uses Framadate, no native polls)
- [ ] `greentap poll-results` (no chat) → exits 1 with usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)