### PR TITLE
chore: update skill + localization guidelines + fix .gitignore

### DIFF
--- a/.claude/skills/greentap/SKILL.md
+++ b/.claude/skills/greentap/SKILL.md
@@ -8,8 +8,9 @@ description: |
   - Search for a contact or group
   - Send a message to a contact or group
   - Draft a message for review before sending
+  - Read poll results from a chat
   Triggers: "whatsapp", "check messages", "read chat", "send message to",
-  "unread messages", "message from", "greentap"
+  "unread messages", "message from", "greentap", "poll results", "sondaggio"
 license: MIT
 compatibility: "Requires Node.js 18+, Google Chrome (system install)"
 allowed-tools: Bash
@@ -40,11 +41,19 @@ node greentap.js read "contact or group name" --json
 # Read full chat history (scrolls up, deduplicates)
 node greentap.js read "contact or group name" --scroll --json
 
+# If multiple chats share the same name, use --index N (1-based) to pick one
+node greentap.js read "contact or group name" --index 2 --json
+node greentap.js send "contact or group name" --index 2 "message text"
+
 # Search for a contact or group (finds archived chats too)
 node greentap.js search "query" --json
 
 # Send a message (finds chat by name, types and sends)
 node greentap.js send "contact or group name" "message text"
+
+# Read poll results from a chat (most recent poll, with vote counts per option)
+node greentap.js poll-results "contact or group name" --json
+node greentap.js poll-results "contact or group name" --index 2 --json
 
 # Daemon management
 node greentap.js status
@@ -57,6 +66,8 @@ node greentap.js daemon stop
 - **read** shows messages visible in the viewport by default; use `--scroll` for full history
 - **read** marks messages as read in WhatsApp (cannot be prevented)
 - **send** verifies correct chat opened and message delivered
+- **poll-results** navigates to the chat and reads the most recent WhatsApp native poll (question + options + vote counts)
+- If multiple chats share the same name, commands error with a numbered list — re-run with `--index N` to pick one
 - Chat matching is case-insensitive substring
 - Locale-agnostic: works with any WhatsApp UI language
 - Own messages have `sender: "You"` in JSON output
@@ -68,5 +79,6 @@ node greentap.js daemon stop
 - When drafting messages, match the language the user typically uses with that contact
 - If asked to "check messages", start with `greentap unread --json`
 - If a chat isn't found, try `greentap search` with a shorter query
+- If asked about poll results or a vote, use `greentap poll-results`
 - Keep tool calls minimal — one `unread` or `read` call is usually enough
 - First command auto-starts daemon (~6s cold start), subsequent ones are ~500ms

--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@ summary_stats.txt
 .agents/
 .worktrees/
 skills/
+!.claude/skills/
 skills-lock.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,26 @@ gh release create v0.x.y --title "v0.x.y — Short title" --notes "..."
 - After a significant decision or discovery → update the risk table if severity/status changed
 - At the start of a new session that changes scope → check if ROADMAP.md reflects reality
 
+## Localization
+
+WhatsApp Web syncs its UI language from the phone — `navigator.language` and Playwright's `locale` option have no effect. All parsing must work regardless of UI language.
+
+**Three-tier strategy — apply in order:**
+
+| Tier | Approach | Examples |
+|------|----------|---------|
+| 1. Structural | ARIA roles + position, no text | `page.getByRole("grid").first()`, `contentinfo` textbox for compose |
+| 2. Icon-based | WhatsApp internal icon IDs (stable, locale-independent) | `img "msg-dblcheck"` / `img "msg-check"` for own messages |
+| 3. Runtime detection | `lib/locale.js` — probes Intl API against chat list content to identify the active locale | Day names, "Yesterday"/"Ieri", date format regex |
+
+**Rules for new code:**
+- Never hardcode locale strings as selectors or parser patterns (no `"lunedì"`, no `"Yesterday"`, no `"Apri dettagli chat di"`)
+- If Tier 1 or 2 cannot cover a pattern, add it to `lib/locale.js` as a detected value passed via `localeConfig`
+- `sender: "You"` is a hardcoded English constant by design — it's the JSON API contract, not a UI string
+- Known gap: sender prefix in group chats (`"Apri dettagli chat di"`) is hardcoded Italian with a regex fallback — treat as tech debt, do not copy the pattern
+
+**Fixtures:** existing fixtures are Italian (phone locale). Keep them — they test parsing logic. New fixtures for new features must also use fake data only (see Constraints).
+
 ## Constraints
 
 - **PUBLIC REPO — NO PII**: This repo is public. NEVER commit real names, phone numbers, email addresses, chat content, or any personally identifiable information. Fixtures use fake names (Roberto Marini, Elena Conti, Famiglia Rossi, etc.). All new fixtures and examples MUST use fake data only.


### PR DESCRIPTION
## Summary
- Update greentap skill with `poll-results` command and `--index` disambiguation flag
- Add localization guidelines to CLAUDE.md (3-tier strategy, rules for new code)
- Unignore `.claude/skills/` in `.gitignore` so skill files track without `-f`

🤖 Generated with [Claude Code](https://claude.com/claude-code)