### PR TITLE
feat: enrich messages with full timestamp from date separators

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -164,7 +164,7 @@ async function findLoadMoreButton(page) {
   });
 }
 
-async function scrollAndCollect(page) {
+async function scrollAndCollect(page, localeConfig) {
   const found = await findScrollContainer(page);
   if (!found) throw new Error("Could not find scrollable message container");
 
@@ -183,7 +183,7 @@ async function scrollAndCollect(page) {
     }
 
     const aria = await page.locator(":root").ariaSnapshot();
-    const msgs = parseMessages(aria);
+    const msgs = parseMessages(aria, { localeConfig });
     iterations.push(msgs);
 
     const firstKey = msgs.length > 0 ? dedupKey(msgs[0]) : null;
@@ -260,10 +260,10 @@ async function scrollAndCollect(page) {
 export async function read(page, chatName, { scroll = false, localeConfig, index } = {}) {
   await navigateToChat(page, chatName, localeConfig, index);
   if (scroll) {
-    return scrollAndCollect(page);
+    return scrollAndCollect(page, localeConfig);
   }
   const aria = await page.locator(":root").ariaSnapshot();
-  return parseMessages(aria);
+  return parseMessages(aria, { localeConfig });
 }
 
 export async function send(page, chatName, message, localeConfig, index) {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -175,6 +175,70 @@ export function printChats(chats) {
 }
 
 /**
+ * Resolve a date separator label to a Date object.
+ * Handles: "Oggi"/"Today" (relative today), "Ieri"/"Yesterday" (relative yesterday),
+ * DD/MM/YYYY absolute dates, and locale day names (most recent past weekday).
+ *
+ * @param {string} text - The separator label text
+ * @param {object} locale - Locale config (dayNames, today, yesterday)
+ * @param {Date} now - Current date (for testability)
+ * @returns {Date|null}
+ */
+function parseDateSeparator(text, locale, now) {
+  const today = now ? new Date(now.getFullYear(), now.getMonth(), now.getDate()) : new Date(new Date().getFullYear(), new Date().getMonth(), new Date().getDate());
+
+  // Locale-string matching only when a localeConfig is explicitly provided.
+  // Without it, we skip today/yesterday/day-name resolution to avoid silent wrong-locale matches.
+  if (locale) {
+    if (text.toLowerCase() === locale.today.toLowerCase()) return new Date(today);
+
+    if (text.toLowerCase() === locale.yesterday.toLowerCase()) {
+      const d = new Date(today);
+      d.setDate(d.getDate() - 1);
+      return d;
+    }
+  }
+
+  // Absolute date: DD/MM/YYYY (European format used in Italian and most locales).
+  // Structural match — no locale needed.
+  const dmyMatch = text.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
+  if (dmyMatch) {
+    return new Date(parseInt(dmyMatch[3]), parseInt(dmyMatch[2]) - 1, parseInt(dmyMatch[1]));
+  }
+
+  if (locale) {
+    // Day name: find most recent past weekday.
+    // dayNames[0]=Monday … dayNames[6]=Sunday → JS DOW: Mon=1 … Sun=0
+    // daysBack=0 (same weekday as today) → use 7: WhatsApp shows "Oggi" for today, never a day name.
+    const dayIdx = locale.dayNames.findIndex((d) => d.toLowerCase() === text.toLowerCase());
+    if (dayIdx !== -1) {
+      const targetDow = (dayIdx + 1) % 7;
+      const daysBack = ((today.getDay() - targetDow + 7) % 7) || 7;
+      const d = new Date(today);
+      d.setDate(d.getDate() - daysBack);
+      return d;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Format a date + HH:MM time as "YYYY-MM-DD HH:MM".
+ * Returns "" if either argument is missing.
+ * @param {Date|null} date
+ * @param {string} time
+ * @returns {string}
+ */
+function formatTimestamp(date, time) {
+  if (!date || !time) return "";
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d} ${time}`;
+}
+
+/**
  * Parse messages from a WhatsApp Web aria snapshot.
  * Uses structural selectors — message rows are rows NOT inside a grid.
  * Own messages detected via delivery status icons (msg-dblcheck / msg-check).
@@ -182,6 +246,8 @@ export function printChats(chats) {
  * @param {string} ariaText
  * @param {object} [options]
  * @param {string} [options.senderButtonPrefix] - Locale-specific prefix for sender buttons
+ * @param {object} [options.localeConfig] - Locale config for date separator detection
+ * @param {Date}   [options.now] - Current date override (for testing)
  */
 export function parseMessages(ariaText, options = {}) {
   if (!ariaText) return [];
@@ -219,14 +285,28 @@ export function parseMessages(ariaText, options = {}) {
 
   if (msgStartIdx < 0) return [];
 
+  const dateSepLocale = options.localeConfig || null;
+  const now = options.now || null;
+
   const messages = [];
   let currentSender = "";
+  let currentDate = null;
 
   // Auto-detect sender button prefix from first sender button encountered
   const senderPrefix = options.senderButtonPrefix || null;
 
   for (let i = msgStartIdx; i < lines.length; i++) {
     const line = lines[i];
+
+    // Date separators are bare `text:` nodes at 2-space indent between message rows
+    // (same level as `row`, `button`, `contentinfo`). There is no ARIA role for them;
+    // 2-space indent is the only structural signal available in the snapshot format.
+    const dateSepMatch = line.match(/^  - text: (.+)$/);
+    if (dateSepMatch) {
+      const parsed = parseDateSeparator(dateSepMatch[1].trim(), dateSepLocale, now);
+      if (parsed) currentDate = parsed;
+      continue;
+    }
 
     // Track sender from buttons between message rows
     // These buttons have a locale-dependent prefix + sender name
@@ -341,7 +421,7 @@ export function parseMessages(ariaText, options = {}) {
 
     if (!text && !time) continue;
 
-    messages.push({ sender, text, time });
+    messages.push({ sender, text, time, timestamp: formatTimestamp(currentDate, time) });
   }
 
   return messages;

--- a/test/fixtures/chat-multiday-aria.txt
+++ b/test/fixtures/chat-multiday-aria.txt
@@ -1,0 +1,37 @@
+- document:
+  - banner:
+    - button "Dettagli profilo":
+      - img
+    - button "Roberto Marini clicca qui per info contatto"
+    - button "Videochiamata": Chiama
+    - button "Cerca"
+    - button "Menu"
+  - text: domenica
+  - button "Apri dettagli chat di Roberto Marini":
+    - img
+  - row "Roberto Marini Fine settimana! 18:00":
+    - text: Roberto Marini Fine settimana! 18:00
+  - text: 18/03/2026
+  - button "Apri dettagli chat di Roberto Marini":
+    - img
+  - row "Roberto Marini Prima di tutto ciao 10:00":
+    - text: Roberto Marini Prima di tutto ciao 10:00
+  - text: Ieri
+  - button "Apri dettagli chat di Roberto Marini":
+    - img
+  - row "Roberto Marini Come va? 09:30":
+    - text: Roberto Marini Come va? 09:30
+  - row "Benissimo grazie 11:00 Letto":
+    - text: Benissimo grazie 11:00
+    - img "msg-dblcheck"
+  - text: Oggi
+  - row "Ci vediamo stasera? 14:00 Consegnato":
+    - text: Ci vediamo stasera? 14:00
+    - img "msg-dblcheck"
+  - button "Apri dettagli chat di Roberto Marini":
+    - img
+  - row "Roberto Marini Perfetto! 14:05":
+    - text: Roberto Marini Perfetto! 14:05
+  - contentinfo:
+    - textbox "Scrivi a Roberto Marini":
+      - paragraph

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -255,6 +255,128 @@ describe("printMessages", () => {
   });
 });
 
+describe("parseMessages — timestamps", () => {
+  // now = Tuesday 2026-03-31 (DOW=2)
+  const NOW = new Date(2026, 2, 31);
+
+  // Italian locale config — passed explicitly per localization rules (Tier 3, no silent fallback)
+  const ITALIAN_TEST_LOCALE = {
+    dayNames: ["lunedì", "martedì", "mercoledì", "giovedì", "venerdì", "sabato", "domenica"],
+    yesterday: "Ieri",
+    today: "Oggi",
+    dateRegex: "\\d{2}\\/\\d{2}\\/\\d{4}",
+  };
+
+  it("adds timestamp field to all messages", () => {
+    const aria = loadFixture("chat-multiday-aria.txt");
+    const messages = parseMessages(aria, { now: NOW, localeConfig: ITALIAN_TEST_LOCALE });
+    assert.ok(messages.length > 0, "should parse messages");
+    for (const m of messages) {
+      assert.ok("timestamp" in m, `message should have timestamp field: ${JSON.stringify(m)}`);
+    }
+  });
+
+  it("preserves time field for backward compatibility", () => {
+    const aria = loadFixture("chat-multiday-aria.txt");
+    const messages = parseMessages(aria, { now: NOW, localeConfig: ITALIAN_TEST_LOCALE });
+    for (const m of messages) {
+      assert.ok(m.time.length > 0, `message should still have time field: ${JSON.stringify(m)}`);
+    }
+  });
+
+  it("produces correct timestamp from DD/MM/YYYY separator", () => {
+    const aria = loadFixture("chat-multiday-aria.txt");
+    // Absolute dates don't need localeConfig — testing without it here to verify
+    const messages = parseMessages(aria, { now: NOW });
+    const msg = messages.find((m) => m.text.includes("Prima di tutto"));
+    assert.ok(msg, "should find 'Prima di tutto' message");
+    assert.equal(msg.timestamp, "2026-03-18 10:00");
+  });
+
+  it("produces correct timestamp from Ieri separator", () => {
+    const aria = loadFixture("chat-multiday-aria.txt");
+    const messages = parseMessages(aria, { now: NOW, localeConfig: ITALIAN_TEST_LOCALE });
+    const msg = messages.find((m) => m.text.includes("Come va?"));
+    assert.ok(msg, "should find 'Come va?' message");
+    assert.equal(msg.timestamp, "2026-03-30 09:30");
+  });
+
+  it("produces correct timestamp from Ieri separator for own messages", () => {
+    const aria = loadFixture("chat-multiday-aria.txt");
+    const messages = parseMessages(aria, { now: NOW, localeConfig: ITALIAN_TEST_LOCALE });
+    const msg = messages.find((m) => m.text.includes("Benissimo"));
+    assert.ok(msg, "should find 'Benissimo' message");
+    assert.equal(msg.timestamp, "2026-03-30 11:00");
+  });
+
+  it("produces correct timestamp from Oggi separator", () => {
+    const aria = loadFixture("chat-multiday-aria.txt");
+    const messages = parseMessages(aria, { now: NOW, localeConfig: ITALIAN_TEST_LOCALE });
+    const msg = messages.find((m) => m.text.includes("Ci vediamo stasera"));
+    assert.ok(msg, "should find 'Ci vediamo stasera' message");
+    assert.equal(msg.timestamp, "2026-03-31 14:00");
+    assert.equal(msg.sender, "You");
+  });
+
+  it("produces correct timestamp from day-name separator (domenica)", () => {
+    const aria = loadFixture("chat-multiday-aria.txt");
+    // now=2026-03-31 (Tuesday DOW=2): domenica (Sunday DOW=0) → 2 days back → 2026-03-29
+    const messages = parseMessages(aria, { now: NOW, localeConfig: ITALIAN_TEST_LOCALE });
+    const msg = messages.find((m) => m.text.includes("Fine settimana"));
+    assert.ok(msg, "should find 'Fine settimana' message");
+    assert.equal(msg.timestamp, "2026-03-29 18:00");
+  });
+
+  it("resolves same-weekday day separator to 7 days back (|| 7 branch)", () => {
+    // now = Monday 2026-03-30 (DOW=1), separator = "lunedì" (Monday, targetDow=1)
+    // daysBack = (1-1+7)%7 = 0 → || 7 → 7 days back → 2026-03-23
+    const nowMonday = new Date(2026, 2, 30);
+    const ariaLunedi = `- document:
+  - banner:
+    - button "Dettagli profilo":
+      - img
+  - text: lunedì
+  - row "Roberto Marini Ciao 09:00":
+    - text: Roberto Marini Ciao 09:00
+  - contentinfo:
+    - textbox "Scrivi"`;
+    const messages = parseMessages(ariaLunedi, { now: nowMonday, localeConfig: ITALIAN_TEST_LOCALE });
+    assert.ok(messages.length > 0, "should parse message");
+    assert.equal(messages[0].timestamp, "2026-03-23 09:00");
+  });
+
+  it("timestamp is empty string when no date separator seen", () => {
+    const ariaNoSep = `- document:
+  - banner:
+    - button "Dettagli profilo":
+      - img
+  - row "Solo 12:00 Consegnato":
+    - text: Solo 12:00
+    - img "msg-dblcheck"
+  - contentinfo:
+    - textbox "Scrivi"`;
+    const messages = parseMessages(ariaNoSep, { now: NOW });
+    assert.ok(messages.length > 0, "should parse at least one message");
+    assert.equal(messages[0].timestamp, "", "timestamp should be empty with no date separator");
+  });
+
+  it("produces timestamp without now when separator is absolute date (production path smoke)", () => {
+    // DD/MM/YYYY doesn't depend on current date — validates the no-now production path
+    const ariaAbsolute = `- document:
+  - banner:
+    - button "Dettagli profilo":
+      - img
+  - text: 18/03/2026
+  - row "Roberto Marini Ciao 10:00":
+    - text: Roberto Marini Ciao 10:00
+  - contentinfo:
+    - textbox "Scrivi"`;
+    const messages = parseMessages(ariaAbsolute); // no now, no localeConfig
+    assert.ok(messages.length > 0, "should parse message");
+    assert.equal(messages[0].timestamp, "2026-03-18 10:00");
+  });
+});
+
 describe("parseSearchResults", () => {
   it("parses search results fixture", () => {
     const aria = loadFixture("search-aria.txt");


### PR DESCRIPTION
## Summary

- WhatsApp aria snapshots include date separators (e.g. `Oggi`, `18/03/2026`, `lunedì`) between message groups. Previously they were silently skipped — messages had only `HH:MM` with no day context.
- `parseMessages` now tracks the current date as it walks the snapshot and produces a `timestamp: "YYYY-MM-DD HH:MM"` field on each message object. The existing `time` field is unchanged (backward compat).
- Locale-string matching (`Oggi`/`Ieri`/day names) is guarded behind an explicit `options.localeConfig` — no silent Italian fallback. Absolute `DD/MM/YYYY` dates work without locale.

## What changed

- `lib/parser.js`: `parseDateSeparator` + `formatTimestamp` helpers; `parseMessages` accepts `options.localeConfig` (Tier 3) and `options.now` (testability)
- `test/fixtures/chat-multiday-aria.txt`: new synthetic fixture (fake names only) covering domenica → absolute date → Ieri → Oggi
- `test/parser.test.js`: 10 new tests — all separator types, `|| 7` same-weekday edge case, no-separator baseline, no-`now` production path smoke

## Test plan

- [ ] `npm test` — 84 tests, all pass
- [ ] Manual: `node greentap.js read "<multi-day chat>" --json` and verify `timestamp` fields are present and correct

## Reviewer notes

The 2-space indent pattern for date separators (`^  - text: XXX`) is the only structural signal available — WhatsApp exposes these as bare ARIA text nodes with no role. A silent failure mode (separator not matched → timestamps empty) is a known limitation documented in the code comment.