### PR TITLE
fix(daemon): harden startup + switch to bundled Chromium (#13, #14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ Uses structural ARIA selectors and runtime locale detection, so it works with an
 ## Prerequisites
 
 - [Node.js](https://nodejs.org/) (v18+)
-- [Google Chrome](https://www.google.com/chrome/) (system install, not Chromium)
-- [Playwright](https://playwright.dev/) (`npm install` handles this)
+- [Playwright](https://playwright.dev/) — bundled Chromium installed via `npx playwright install chromium` (`npm install` runs this automatically)
 
 ## Install
 
@@ -18,7 +17,10 @@ Uses structural ARIA selectors and runtime locale detection, so it works with an
 git clone https://github.com/psacc/greentap.git
 cd greentap
 npm install
+npx playwright install chromium   # if not run automatically by your setup
 ```
+
+> **v0.3.2+ note:** greentap now uses Playwright's bundled Chromium (was system Chrome). If you upgraded from v0.3.1 or earlier, you will need to re-scan the QR code via `greentap login` — browser profile data is not portable between Chrome and Chromium.
 
 First run — scan the QR code to link your WhatsApp account:
 
@@ -26,7 +28,7 @@ First run — scan the QR code to link your WhatsApp account:
 node greentap.js login
 ```
 
-This opens a headed Chrome window. Scan the QR code with your phone, then close the browser. Session data is stored in `~/.greentap/browser-data/`.
+This opens a headed Chromium window. Scan the QR code with your phone, then close the browser. Session data is stored in `~/.greentap/browser-data/`.
 
 ## Usage
 
@@ -66,7 +68,7 @@ node greentap.js logout
 
 greentap drives WhatsApp Web through Playwright's CDP connection to a persistent Chrome instance.
 
-1. **Browser daemon**: The first command auto-launches a headless Chrome instance on CDP port 19222. It stays alive for 15 minutes of idle time, so subsequent commands are fast (~500ms).
+1. **Browser daemon**: The first command auto-launches a headless Chromium instance (Playwright's bundled build) on CDP port 19222. It stays alive for 15 minutes of idle time, so subsequent commands are fast (~500ms).
 
 2. **Aria snapshots**: Instead of fragile CSS selectors (WhatsApp obfuscates classes and changes them frequently), greentap reads the page's accessibility tree. Chat lists, messages, compose boxes, and buttons are identified by ARIA roles and structural position.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -37,7 +37,7 @@ Migrating to Playwright on WhatsApp Web, following the same pattern as hey-cli.
 | Account ban (ToS violation) | Medium | Low volume, human-like delays, personal account |
 | Session expires (14-day inactivity) | Low | Keep sessions active, `greentap login` to re-auth |
 | Aria labels are locale-dependent | Low | Mitigated: structural ARIA selectors + runtime locale detection (Phase 6) |
-| WhatsApp rejects bundled Chromium | Medium | Use system Chrome (`channel: "chrome"`), headless mode |
+| WhatsApp rejects bundled Chromium | Pending verification (2026-04-22) | Switched to bundled Chromium in v0.3.2 for CDP port isolation. If WA rejects, revert `channel: "chrome"` and open issue for user-agent spoofing. |
 | Aria tree restructuring (WA updates) | Medium | Two row formats already handled; parser may need updates |
 
 **Current: Phase 7 (explore)**

--- a/docs/superpowers/plans/2026-04-22-daemon-hardening.md
+++ b/docs/superpowers/plans/2026-04-22-daemon-hardening.md
@@ -1,0 +1,299 @@
+# Daemon Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix two independent daemon reliability issues: (1) client timeout during cold start, (2) CDP port conflicts + lack of browser isolation.
+
+**Architecture:** Write the port file *before* launching Chromium (port is a fixed constant 19222, so we know it upfront); remove `channel: "chrome"` so the daemon uses Playwright's bundled Chromium instead of the user's system Chrome.
+
+**Tech Stack:** Node.js ESM, Playwright `launchPersistentContext`, CDP over TCP port 19222.
+
+---
+
+## Context you need
+
+- [Issue #13](https://github.com/psacc-labs/greentap/issues/13): `lib/daemon.js:88` writes `daemon.port` only *after* `chromium.launchPersistentContext()` returns (15–30s cold start). Client in `lib/client.js:147-153` polls for the port file with a 15s deadline and times out.
+- [Issue #14](https://github.com/psacc-labs/greentap/issues/14): `lib/daemon.js:78` uses `channel: "chrome"` (system Chrome). This causes version drift and CDP port conflicts when the user also runs Chrome normally.
+- Both changes live in `lib/daemon.js`. Apply sequentially to avoid internal conflicts.
+- After Task 2, the persistent profile at `~/.greentap/browser-data/` may need re-login (Chrome ↔ Chromium profile format differs). Document in release notes.
+
+## File Structure
+
+- Modify: `lib/daemon.js` — port file write order + remove `channel`
+- Modify: `test/daemon.test.js` — create if absent, add integration test for port-file-before-launch
+- Modify: `README.md` — note re-login may be required after v0.3.2
+- Modify: `ROADMAP.md` — risk row "WhatsApp rejects bundled Chromium" — update after verification
+
+---
+
+## Task 1: Write port file before Chrome launch
+
+**Files:**
+- Modify: `lib/daemon.js:70-89`
+- Test: `test/daemon.test.js` (new file)
+
+- [ ] **Step 1: Write failing test**
+
+Create `test/daemon.test.js`:
+
+```javascript
+import { test } from "node:test";
+import assert from "node:assert";
+import { readFileSync, existsSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+
+const PORT_FILE = join(homedir(), ".greentap", "daemon.port");
+
+test("daemon writes port file before Chrome launch finishes", async () => {
+  // This test asserts post-condition: after daemon starts (up to 2s),
+  // the port file exists even if Chrome is still launching.
+  // Precondition: daemon not running, port file absent.
+  // Run manually: `node lib/daemon.js &` then within 2s check existsSync(PORT_FILE).
+  // Automated variant: fork daemon, poll for file within 2s, assert success, SIGTERM.
+  const { fork } = await import("child_process");
+  const child = fork("lib/daemon.js", [], { detached: true, stdio: "ignore" });
+  try {
+    const deadline = Date.now() + 2000;
+    let found = false;
+    while (Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 100));
+      if (existsSync(PORT_FILE)) { found = true; break; }
+    }
+    assert.strictEqual(found, true, "port file should exist within 2s");
+    const port = parseInt(readFileSync(PORT_FILE, "utf8").trim(), 10);
+    assert.strictEqual(port, 19222);
+  } finally {
+    try { process.kill(child.pid, "SIGTERM"); } catch {}
+  }
+});
+```
+
+- [ ] **Step 2: Run test, confirm failure**
+
+Run: `node --test test/daemon.test.js`
+Expected: FAIL — port file appears after Chrome launch (typically 15-30s), not within 2s deadline.
+
+- [ ] **Step 3: Move port file write above `launchPersistentContext`**
+
+Edit `lib/daemon.js`. Replace lines 70-89 (the start of `main()` up to and including the `writeAtomic(PID_FILE, ...)` line) with:
+
+```javascript
+async function main() {
+  // Ensure ~/.greentap/ exists with 0700
+  mkdirSync(GREENTAP_DIR, { recursive: true, mode: 0o700 });
+  chmodSync(GREENTAP_DIR, 0o700);
+
+  // Write port + PID files BEFORE launching Chrome. Port is a known constant
+  // (CDP_PORT = 19222); clients tryConnect() will retry until the CDP server
+  // is actually listening. Fixes #13 where clients timed out during cold
+  // start (15-30s) because the port file appeared only after launch.
+  writeAtomic(PORT_FILE, String(CDP_PORT));
+  writeAtomic(PID_FILE, String(process.pid));
+
+  // Launch persistent context with CDP
+  context = await chromium.launchPersistentContext(USER_DATA_DIR, {
+    headless: true,
+    channel: "chrome",
+    viewport: { width: 1280, height: 900 },
+    args: [
+      "--disable-blink-features=AutomationControlled",
+      `--remote-debugging-port=${CDP_PORT}`,
+      "--remote-debugging-address=127.0.0.1",
+    ],
+  });
+```
+
+- [ ] **Step 4: Verify `client.js` tryConnect already retries**
+
+Read `lib/client.js:122-137` — `tryConnect` uses `chromium.connectOverCDP` with 5s timeout. This is called once; if CDP isn't listening yet, it throws. The outer loop in `connect()` does NOT retry `tryConnect` on failure — it calls `cleanupStaleFiles()` and starts a new daemon. This means: with the fix, the first `tryConnect` may still fail during cold start.
+
+Therefore, also patch `lib/client.js`. Replace lines 206-221 (the "Try existing daemon" block) with:
+
+```javascript
+  // Try existing daemon (with CDP-listening retry for cold start)
+  let port = readPort();
+  if (port) {
+    const pid = readPid();
+    const daemonAlive = pid && isProcessAlive(pid);
+    const deadline = Date.now() + (daemonAlive ? 30000 : 5000);
+    let lastErr = null;
+    while (Date.now() < deadline) {
+      try {
+        const { browser, page } = await tryConnect(port);
+        await ensureChatList(page);
+        const localeConfig = await detectLocale(page);
+        return {
+          page,
+          disconnect: () => browser.close(),
+          localeConfig,
+        };
+      } catch (err) {
+        lastErr = err;
+        if (!daemonAlive) break;
+        await new Promise((r) => setTimeout(r, 500));
+      }
+    }
+    // Stale port file (or daemon stuck)
+    cleanupStaleFiles();
+  }
+```
+
+- [ ] **Step 5: Run test, confirm pass**
+
+Run: `node --test test/daemon.test.js`
+Expected: PASS within 2s.
+
+- [ ] **Step 6: Full suite**
+
+Run: `npm test`
+Expected: all tests pass.
+
+- [ ] **Step 7: Manual smoke test**
+
+```bash
+node greentap.js daemon stop
+rm -f ~/.greentap/daemon.port ~/.greentap/daemon.pid
+time node greentap.js status
+```
+
+Expected: first call succeeds in <5s on warm daemon, <35s on cold start (no spurious "Daemon failed to start within 15s").
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add lib/daemon.js lib/client.js test/daemon.test.js
+git commit -m "fix(daemon): write port file before Chrome launch (#13)
+
+Clients waited up to 15s for the port file, but launchPersistentContext
+takes 15-30s on cold start. Write the port file up front (port is the
+fixed constant 19222) and let tryConnect retry while Chrome warms up."
+```
+
+---
+
+## Task 2: Remove `channel: "chrome"` to use bundled Chromium
+
+**Files:**
+- Modify: `lib/daemon.js:78`
+- Modify: `package.json` — add postinstall to ensure Chromium is present (optional — decide in Step 3)
+- Modify: `README.md` — installation note
+- Test: manual — WhatsApp Web must render + allow login
+
+- [ ] **Step 1: Verify Playwright bundled Chromium is installed**
+
+Run: `npx playwright install chromium`
+Expected: "chromium <version> is already installed" or successful install.
+
+- [ ] **Step 2: Back up existing session**
+
+Existing `~/.greentap/browser-data/` was created by system Chrome. Profile format may not be compatible with bundled Chromium. Back up before swapping:
+
+```bash
+mv ~/.greentap/browser-data ~/.greentap/browser-data.chrome-backup
+```
+
+- [ ] **Step 3: Remove `channel` option**
+
+Edit `lib/daemon.js`. Delete line 78:
+
+```javascript
+    channel: "chrome",
+```
+
+Resulting block:
+
+```javascript
+  context = await chromium.launchPersistentContext(USER_DATA_DIR, {
+    headless: true,
+    viewport: { width: 1280, height: 900 },
+    args: [
+      "--disable-blink-features=AutomationControlled",
+      `--remote-debugging-port=${CDP_PORT}`,
+      "--remote-debugging-address=127.0.0.1",
+    ],
+  });
+```
+
+- [ ] **Step 4: Stop existing daemon and re-login**
+
+```bash
+node greentap.js daemon stop
+node greentap.js login
+# scan QR
+```
+
+Expected: login succeeds; headless check — WhatsApp Web accepts bundled Chromium. If WA blocks with "update your browser" banner, revert this task and open a follow-up issue for user-agent spoofing.
+
+- [ ] **Step 5: Smoke test read-only commands**
+
+```bash
+node greentap.js chats --json | head -20
+node greentap.js unread --json
+```
+
+Expected: output JSON with real chat data (verify no errors in output).
+
+- [ ] **Step 6: Run test suite**
+
+Run: `npm test`
+Expected: all tests pass.
+
+- [ ] **Step 7: Update README**
+
+Edit `README.md`. In the Installation section, add after the existing `npm install` instructions:
+
+```markdown
+> **v0.3.2+ note:** greentap now uses Playwright's bundled Chromium (was system Chrome). The Chromium binary is installed via `npx playwright install chromium` (run automatically by `npm install`). If you upgraded from an earlier version, you will need to re-scan the QR code via `greentap login` since browser profile data is not portable between Chrome and Chromium.
+```
+
+- [ ] **Step 8: Update ROADMAP risk table**
+
+Edit `ROADMAP.md` line 41. Change:
+
+```
+| WhatsApp rejects bundled Chromium | Medium | Use system Chrome (`channel: "chrome"`), headless mode |
+```
+
+to:
+
+```
+| WhatsApp rejects bundled Chromium | Verified OK as of 2026-04 | Bundled Chromium tested with headless + automation-controlled disabled |
+```
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add lib/daemon.js README.md ROADMAP.md
+git commit -m "fix(daemon): use bundled Chromium instead of system Chrome (#14)
+
+Eliminates CDP port conflicts with the user's own Chrome, removes version
+drift risk, and isolates greentap's browser profile. Users upgrading from
+v0.3.1 will need to re-login (profile formats differ)."
+```
+
+- [ ] **Step 10: Cleanup backup**
+
+After a day of successful use:
+
+```bash
+rm -rf ~/.greentap/browser-data.chrome-backup
+```
+
+---
+
+## Release
+
+After both tasks merge:
+
+```bash
+git tag v0.3.2
+git push origin v0.3.2
+gh release create v0.3.2 \
+  --title "v0.3.2 — Daemon hardening" \
+  --notes "**Fixes**
+- Daemon port file written before Chrome launch — eliminates 15s client timeout on cold start (#13)
+- Switch from system Chrome to bundled Chromium — no CDP port conflicts, profile isolation (#14)
+
+**Upgrade note:** re-run \`greentap login\` after upgrading (Chrome and Chromium use different profile formats)."
+```

--- a/lib/client.js
+++ b/lib/client.js
@@ -202,22 +202,35 @@ export async function connect() {
     throw new Error("No session. Run `greentap login` first.");
   }
 
-  // Try existing daemon
+  // Try existing daemon (with CDP-listening retry for cold start).
+  // Since #13 fix, the daemon writes the port file *before* Chrome is
+  // listening, so the first tryConnect may fail while Chrome is still
+  // warming up (15-30s). Retry while the daemon PID is alive.
   let port = readPort();
   if (port) {
-    try {
-      const { browser, page } = await tryConnect(port);
-      await ensureChatList(page);
-      const localeConfig = await detectLocale(page);
-      return {
-        page,
-        disconnect: () => browser.close(),
-        localeConfig,
-      };
-    } catch {
-      // Stale port file
-      cleanupStaleFiles();
+    const pid = readPid();
+    const daemonAlive = pid !== null && isProcessAlive(pid);
+    const deadline = Date.now() + (daemonAlive ? 30000 : 5000);
+    let connected = false;
+    while (Date.now() < deadline) {
+      try {
+        const { browser, page } = await tryConnect(port);
+        await ensureChatList(page);
+        const localeConfig = await detectLocale(page);
+        return {
+          page,
+          disconnect: () => browser.close(),
+          localeConfig,
+        };
+      } catch {
+        if (!daemonAlive) break;
+        await new Promise((r) => setTimeout(r, 500));
+      }
     }
+    // Reaching here means every tryConnect within the deadline threw
+    // (or the daemon PID was dead). Treat as stale and fall through to
+    // starting a fresh daemon under the lock.
+    cleanupStaleFiles();
   }
 
   // Start daemon under lock

--- a/lib/client.js
+++ b/lib/client.js
@@ -211,7 +211,6 @@ export async function connect() {
     const pid = readPid();
     const daemonAlive = pid !== null && isProcessAlive(pid);
     const deadline = Date.now() + (daemonAlive ? 30000 : 5000);
-    let connected = false;
     while (Date.now() < deadline) {
       try {
         const { browser, page } = await tryConnect(port);
@@ -227,9 +226,19 @@ export async function connect() {
         await new Promise((r) => setTimeout(r, 500));
       }
     }
-    // Reaching here means every tryConnect within the deadline threw
-    // (or the daemon PID was dead). Treat as stale and fall through to
-    // starting a fresh daemon under the lock.
+    // Reaching here means every tryConnect within the deadline threw.
+    // If the daemon PID was dead, files are safely stale — clean up and
+    // fall through to spawning a fresh one.
+    // If the daemon PID was alive but we never got a usable CDP connection,
+    // the daemon is wedged (started but can't serve). Surface an actionable
+    // error instead of silently deleting its metadata — otherwise we'd
+    // spawn a second daemon that collides on port 19222.
+    if (daemonAlive) {
+      throw new Error(
+        `Daemon (PID ${pid}) is running but not responding on CDP within 30s. ` +
+          `Run \`greentap daemon stop\` (or kill -9 ${pid}) and retry.`,
+      );
+    }
     cleanupStaleFiles();
   }
 

--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -5,8 +5,9 @@
  * Exposes CDP on port 19222 for CLI clients to connect via connectOverCDP.
  *
  * Lifecycle:
- *   - Launches Chrome with persistent context + CDP
- *   - Writes port + PID files atomically
+ *   - Writes port + PID files atomically (before launch, so clients can
+ *     wait for CDP without a race — see #13)
+ *   - Launches Chromium (bundled with Playwright) with persistent context + CDP
  *   - Navigates to WhatsApp Web, waits for chat list
  *   - Monitors CDP connections to reset idle timer
  *   - Shuts down after 15min idle, SIGTERM, or browser crash
@@ -30,7 +31,14 @@ const USER_DATA_DIR = join(GREENTAP_DIR, "browser-data");
 const PORT_FILE = join(GREENTAP_DIR, "daemon.port");
 const PID_FILE = join(GREENTAP_DIR, "daemon.pid");
 const WA_URL = "https://web.whatsapp.com";
-const CDP_PORT = parseInt(process.env.GREENTAP_CDP_PORT || "19222", 10);
+const CDP_PORT_DEFAULT = 19222;
+const CDP_PORT = (() => {
+  const raw = process.env.GREENTAP_CDP_PORT;
+  if (!raw) return CDP_PORT_DEFAULT;
+  const n = parseInt(raw, 10);
+  if (!Number.isFinite(n) || n <= 0 || n > 65535) return CDP_PORT_DEFAULT;
+  return n;
+})();
 const IDLE_TIMEOUT_MS = 15 * 60 * 1000;
 
 let context = null;

--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -81,10 +81,12 @@ async function main() {
   writeAtomic(PORT_FILE, String(CDP_PORT));
   writeAtomic(PID_FILE, String(process.pid));
 
-  // Launch persistent context with CDP
+  // Launch persistent context with CDP.
+  // Uses Playwright's bundled Chromium (no `channel: "chrome"`) to avoid
+  // CDP port conflicts with the user's own Chrome and to pin the browser
+  // version. Fixes #14.
   context = await chromium.launchPersistentContext(USER_DATA_DIR, {
     headless: true,
-    channel: "chrome",
     viewport: { width: 1280, height: 900 },
     args: [
       "--disable-blink-features=AutomationControlled",

--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -23,12 +23,14 @@ import {
   chmodSync,
 } from "fs";
 
-const GREENTAP_DIR = join(homedir(), ".greentap");
+// GREENTAP_DIR and GREENTAP_CDP_PORT env vars exist for test isolation only.
+// Production users should never set them — defaults are the documented paths.
+const GREENTAP_DIR = process.env.GREENTAP_DIR || join(homedir(), ".greentap");
 const USER_DATA_DIR = join(GREENTAP_DIR, "browser-data");
 const PORT_FILE = join(GREENTAP_DIR, "daemon.port");
 const PID_FILE = join(GREENTAP_DIR, "daemon.pid");
 const WA_URL = "https://web.whatsapp.com";
-const CDP_PORT = 19222;
+const CDP_PORT = parseInt(process.env.GREENTAP_CDP_PORT || "19222", 10);
 const IDLE_TIMEOUT_MS = 15 * 60 * 1000;
 
 let context = null;
@@ -72,6 +74,13 @@ async function main() {
   mkdirSync(GREENTAP_DIR, { recursive: true, mode: 0o700 });
   chmodSync(GREENTAP_DIR, 0o700);
 
+  // Write port + PID files BEFORE launching Chrome. Port is a known constant
+  // (CDP_PORT = 19222); clients tryConnect() will retry until the CDP server
+  // is actually listening. Fixes #13 where clients timed out during cold
+  // start (15-30s) because the port file appeared only after launch.
+  writeAtomic(PORT_FILE, String(CDP_PORT));
+  writeAtomic(PID_FILE, String(process.pid));
+
   // Launch persistent context with CDP
   context = await chromium.launchPersistentContext(USER_DATA_DIR, {
     headless: true,
@@ -83,10 +92,6 @@ async function main() {
       "--remote-debugging-address=127.0.0.1",
     ],
   });
-
-  // Write port + PID files atomically
-  writeAtomic(PORT_FILE, String(CDP_PORT));
-  writeAtomic(PID_FILE, String(process.pid));
 
   // Navigate to WhatsApp Web
   const page = context.pages()[0] || (await context.newPage());

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "greentap": "./greentap.js"
   },
   "scripts": {
-    "test": "node --test 'test/**/*.test.js'"
+    "test": "node --test 'test/**/*.test.js'",
+    "postinstall": "playwright install chromium"
   },
   "type": "module",
   "dependencies": {

--- a/test/daemon.test.js
+++ b/test/daemon.test.js
@@ -1,0 +1,99 @@
+import { test } from "node:test";
+import assert from "node:assert";
+import { readFileSync, existsSync, mkdtempSync, rmSync } from "fs";
+import { join, dirname } from "path";
+import { tmpdir } from "os";
+import { fork } from "child_process";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DAEMON_SCRIPT = join(__dirname, "..", "lib", "daemon.js");
+const DAEMON_SOURCE = readFileSync(DAEMON_SCRIPT, "utf8");
+
+// Fixed CDP port the daemon uses. The test below asserts the port file is
+// written up front (issue #13) so clients don't time out during Chrome's
+// 15-30s cold start.
+const EXPECTED_PORT = 19222;
+
+test("daemon writes port file before Chrome launch finishes", async () => {
+  // Isolate from the user's real ~/.greentap/ by overriding the base dir.
+  // The daemon honors GREENTAP_DIR as a test/override hook.
+  const tmpDir = mkdtempSync(join(tmpdir(), "greentap-test-"));
+  const portFile = join(tmpDir, "daemon.port");
+  const pidFile = join(tmpDir, "daemon.pid");
+
+  // Unique CDP port per-test to avoid colliding with anything else on the box.
+  // The daemon honors GREENTAP_CDP_PORT for the same reason.
+  const testPort = 19333;
+
+  const child = fork(DAEMON_SCRIPT, [], {
+    detached: true,
+    stdio: "ignore",
+    env: {
+      ...process.env,
+      GREENTAP_DIR: tmpDir,
+      GREENTAP_CDP_PORT: String(testPort),
+    },
+  });
+
+  try {
+    // Poll for the port file for up to 2s. Chrome cold-start takes 15-30s,
+    // so if the file appears within 2s the write must have happened before
+    // launchPersistentContext returned — which is the behavior we want.
+    const deadline = Date.now() + 2000;
+    let found = false;
+    while (Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 50));
+      if (existsSync(portFile)) {
+        found = true;
+        break;
+      }
+    }
+
+    assert.strictEqual(
+      found,
+      true,
+      "port file should exist within 2s (before Chrome launch completes)",
+    );
+
+    const port = parseInt(readFileSync(portFile, "utf8").trim(), 10);
+    assert.strictEqual(port, testPort, "port file should contain the CDP port");
+
+    // PID file should also be written up front.
+    assert.ok(existsSync(pidFile), "pid file should exist alongside port file");
+  } finally {
+    try {
+      process.kill(child.pid, "SIGKILL");
+    } catch {
+      // already gone
+    }
+    // Small grace period for the child to actually exit before we rm the dir
+    // (Chromium may still be spawning; SIGKILL the group is best-effort here).
+    try {
+      process.kill(-child.pid, "SIGKILL");
+    } catch {
+      // no process group or already gone
+    }
+    await new Promise((r) => setTimeout(r, 200));
+    try {
+      rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      // best effort — browser-data subdir may still be in use
+    }
+  }
+});
+
+test("daemon source writes port file before launchPersistentContext", () => {
+  // Belt-and-braces static check: the port file write must appear in the
+  // source text *before* the launchPersistentContext call. This guards
+  // against regressions even on CI where forking the daemon is undesirable.
+  const portWriteIdx = DAEMON_SOURCE.indexOf("writeAtomic(PORT_FILE");
+  const launchIdx = DAEMON_SOURCE.indexOf("launchPersistentContext");
+
+  assert.ok(portWriteIdx > 0, "daemon must call writeAtomic(PORT_FILE, ...)");
+  assert.ok(launchIdx > 0, "daemon must call launchPersistentContext");
+  assert.ok(
+    portWriteIdx < launchIdx,
+    `port file write (idx ${portWriteIdx}) must precede launchPersistentContext (idx ${launchIdx})`,
+  );
+});

--- a/test/daemon.test.js
+++ b/test/daemon.test.js
@@ -97,3 +97,27 @@ test("daemon source writes port file before launchPersistentContext", () => {
     `port file write (idx ${portWriteIdx}) must precede launchPersistentContext (idx ${launchIdx})`,
   );
 });
+
+test("daemon does not pin channel:'chrome' — uses bundled Chromium (#14)", () => {
+  // Static check: the `channel: "chrome"` option must be absent from
+  // launchPersistentContext. Using bundled Chromium isolates greentap's
+  // browser from the user's system Chrome (no CDP port conflicts, no
+  // version drift).
+  //
+  // Strip line and block comments first so explanatory text mentioning
+  // `channel: "chrome"` in docstrings doesn't trip the assertion.
+  const sourceNoComments = DAEMON_SOURCE
+    .replace(/\/\*[\s\S]*?\*\//g, "") // block comments
+    .replace(/\/\/[^\n]*/g, ""); // line comments
+
+  // Matches any whitespace/quoting variant:
+  //   channel: "chrome"
+  //   channel:'chrome'
+  //   channel :  "chrome"
+  const channelPattern = /channel\s*:\s*['"]chrome['"]/;
+  assert.strictEqual(
+    channelPattern.test(sourceNoComments),
+    false,
+    "daemon.js must not pin channel:'chrome' — should use bundled Chromium",
+  );
+});

--- a/test/daemon.test.js
+++ b/test/daemon.test.js
@@ -10,11 +10,6 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const DAEMON_SCRIPT = join(__dirname, "..", "lib", "daemon.js");
 const DAEMON_SOURCE = readFileSync(DAEMON_SCRIPT, "utf8");
 
-// Fixed CDP port the daemon uses. The test below asserts the port file is
-// written up front (issue #13) so clients don't time out during Chrome's
-// 15-30s cold start.
-const EXPECTED_PORT = 19222;
-
 test("daemon writes port file before Chrome launch finishes", async () => {
   // Isolate from the user's real ~/.greentap/ by overriding the base dir.
   // The daemon honors GREENTAP_DIR as a test/override hook.


### PR DESCRIPTION
## Summary

Fixes two daemon reliability issues:
- **#13** — port file now written *before* `launchPersistentContext()` (was written after, causing 15s client timeouts on cold start). Client retries CDP connect while Chrome warms up.
- **#14** — replaces `channel: "chrome"` (system Chrome) with Playwright's bundled Chromium. No more CDP port conflicts with the user's own browser; profile is isolated.

Plan: [`docs/superpowers/plans/2026-04-22-daemon-hardening.md`](docs/superpowers/plans/2026-04-22-daemon-hardening.md)

## Commits (4)

1. `docs: add daemon hardening implementation plan`
2. `fix(daemon): write port file before Chrome launch (#13)`
3. `fix(daemon): use bundled Chromium instead of system Chrome (#14)`
4. `fix(client): error on wedged daemon instead of spawning a duplicate` — added during `/review-code` (blocker fix: second daemon would collide on port 19222)

## Tests

`npm test`: 87 passing, 0 failing (+3 new daemon tests).

## Review findings

- `/review-code`: 1 blocker fixed (wedged-daemon duplicate spawn), 3 advisories applied.
- `/review-security`: 0 blockers. Advisories (not actioned, your call):
  - `postinstall` hook silently downloads ~200MB Chromium on every install.
  - `GREENTAP_CDP_PORT` env var could be gated to `NODE_ENV=test`.

## Plan deviations

- Added `GREENTAP_DIR` / `GREENTAP_CDP_PORT` env-var overrides to `daemon.js` so daemon tests don't touch your live `~/.greentap/`. Documented in-code as test-only. Worth a look.

## Manual steps required before release

1. `node greentap.js daemon stop`
2. `npx playwright install chromium`
3. `mv ~/.greentap/browser-data ~/.greentap/browser-data.chrome-backup`
4. `node greentap.js login` + scan QR
5. Smoke test: `node greentap.js chats --json`
6. If WhatsApp rejects bundled Chromium → revert `fix(daemon): use bundled Chromium...`
7. If all green → update `ROADMAP.md` risk row from "Pending verification" to "Verified OK"

## Test plan

- [ ] Stop existing daemon, remove old profile, re-login with bundled Chromium
- [ ] Run `greentap chats --json` — confirms WA rendering works headless
- [ ] Cold-start timing: `time greentap status` → first call <35s
- [ ] Confirms #13 fix: port file appears within 2s of daemon start

Closes #13
Closes #14