### PR TITLE
fix(navigate): wait for chat grid + --index in search fallback

### DIFF
--- a/docs/superpowers/plans/2026-04-22-navigatetochat-robustness.md
+++ b/docs/superpowers/plans/2026-04-22-navigatetochat-robustness.md
@@ -1,0 +1,304 @@
+# navigateToChat Determinism Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate non-deterministic behavior in `navigateToChat` where the chat grid isn't rendered at query time, causing the search fallback to be used even for visible chats — which fails for short/generic names (e.g. `"Foot"`).
+
+**Architecture:** Add a bounded `waitFor(grid)` *before* deciding between "parse grid" vs "search fallback". Treat the grid path as the primary, deterministic route; only fall back to search when the grid is legitimately unavailable (archived chats, not in current viewport after wait).
+
+**Tech Stack:** Playwright ARIA selectors, `getByRole("grid")`, `waitFor({ timeout })`.
+
+---
+
+## Context you need
+
+- Bug observed 2026-03-29: `navigateToChat` calls `chatGrid.isVisible()` with no wait. When the grid hasn't rendered yet (cold connection, tab switch), `isVisible()` returns false → search fallback runs → for short names like `"Foot"` search matches many chats and `find(c => c.name === chatName)` may miss the intended one.
+- Current code: `lib/commands.js:25-95`, specifically `isVisible().catch(() => false)` at line 28.
+- Search fallback also has no `--index` support (line 58 comment): if duplicates exist only in search results, it silently picks the first.
+- Fix direction: replace `isVisible()` with `waitFor({ state: "visible", timeout: 2000 })` to give the grid a real chance to render; only fall through to search on true timeout.
+
+## File Structure
+
+- Modify: `lib/commands.js` — `navigateToChat` (lines 25-95)
+- Modify: `test/cli.test.js` (or new `test/navigate.test.js`) — deterministic-path and fallback-path tests with fake `page` doubles
+- Optional: extract `navigateToChat` into its own module `lib/navigate.js` if the function grows; decide in Task 3.
+
+---
+
+## Task 1: Test — grid-path used when grid is visible after wait
+
+**Files:**
+- Create or modify: `test/navigate.test.js`
+
+- [ ] **Step 1: Write failing test**
+
+Create `test/navigate.test.js`:
+
+```javascript
+import { test } from "node:test";
+import assert from "node:assert";
+import { navigateToChat } from "../lib/commands.js";
+
+// Fake ARIA snapshot for the chat grid. "Roberto Marini" (row) with 1 chat.
+// Helper: build a minimal fake `page` that satisfies the selectors
+// navigateToChat uses: getByRole("grid").first() → isVisible/ariaSnapshot/getByRole("row").
+function makeFakePage({ gridVisibleAfterMs = 0, gridAria = "", searchAria = "", headerAria = "" } = {}) {
+  const started = Date.now();
+  const gridIsVisible = () => (Date.now() - started) >= gridVisibleAfterMs;
+
+  const row = {
+    click: async () => {},
+    first: function () { return this; },
+    filter: function () { return this; },
+  };
+
+  const grid = {
+    waitFor: async ({ timeout = 10000 } = {}) => {
+      const deadline = Date.now() + timeout;
+      while (Date.now() < deadline) {
+        if (gridIsVisible()) return;
+        await new Promise(r => setTimeout(r, 50));
+      }
+      throw new Error("timeout");
+    },
+    isVisible: async () => gridIsVisible(),
+    ariaSnapshot: async () => gridAria,
+    getByRole: (role, opts) => row,
+    first: function () { return this; },
+  };
+
+  const page = {
+    getByRole: (role) => (role === "grid" ? { first: () => grid } : {
+      first: () => ({ click: async () => {}, isVisible: async () => true }),
+      getByRole: () => row,
+    }),
+    locator: () => ({ ariaSnapshot: async () => headerAria + searchAria }),
+    keyboard: { type: async () => {}, press: async () => {} },
+  };
+  return page;
+}
+
+test("navigateToChat uses grid path when grid becomes visible within wait window", async () => {
+  const gridAria = `
+- grid:
+    - row "Roberto Marini, ultimo messaggio": /* abbreviated fixture */
+      - gridcell "Roberto Marini 12:34"
+`;
+  const page = makeFakePage({ gridVisibleAfterMs: 500, gridAria, headerAria: 'button "Roberto Marini"' });
+  // Will fail initially because current navigateToChat uses isVisible() without wait.
+  await navigateToChat(page, "Roberto Marini", /* localeConfig */ null);
+  // If it reached here without calling the search fallback, the grid path won.
+  // We assert by proxy: fake page's search path would throw "Chat not found"
+  // since searchAria is empty.
+});
+```
+
+Note: if `parseChatList` can't read this abbreviated fixture, reuse an anonymized full fixture from `test/fixtures/` and wrap it in the fake page. The test's goal is to prove the code path — not parser correctness.
+
+- [ ] **Step 2: Run, confirm failure**
+
+Run: `node --test test/navigate.test.js`
+Expected: FAIL (grid not visible at query time → current code falls to search → throws).
+
+## Task 2: Replace `isVisible()` check with bounded `waitFor`
+
+**Files:**
+- Modify: `lib/commands.js:25-30`
+
+- [ ] **Step 1: Edit `navigateToChat`**
+
+Replace lines 25-30 of `lib/commands.js`. Current:
+
+```javascript
+export async function navigateToChat(page, chatName, localeConfig, index = undefined) {
+  // Try visible chat list first — parse aria for exact name match
+  const chatGrid = page.getByRole("grid").first();
+  if (await chatGrid.isVisible().catch(() => false)) {
+```
+
+New:
+
+```javascript
+export async function navigateToChat(page, chatName, localeConfig, index = undefined) {
+  // Try visible chat list first — parse aria for exact name match.
+  // Wait up to 2s for the grid to render before falling back to search.
+  // Without this wait, a freshly-opened daemon may see isVisible()=false
+  // even when the grid is about to paint, causing spurious search fallback.
+  const chatGrid = page.getByRole("grid").first();
+  const gridReady = await chatGrid.waitFor({ state: "visible", timeout: 2000 }).then(() => true).catch(() => false);
+  if (gridReady) {
+```
+
+- [ ] **Step 2: Run previous test, confirm pass**
+
+Run: `node --test test/navigate.test.js`
+Expected: PASS (500ms visibility delay is well within 2000ms wait).
+
+- [ ] **Step 3: Add test for true-fallback case**
+
+Append to `test/navigate.test.js`:
+
+```javascript
+test("navigateToChat falls back to search when grid never appears", async () => {
+  const page = makeFakePage({
+    gridVisibleAfterMs: 10000,  // grid "never" shows within 2s wait
+    searchAria: `- grid:\n  - row:\n    - gridcell "Elena Conti 14:22"\n`,
+    headerAria: 'button "Elena Conti"',
+  });
+  // Fake page's search path must not throw
+  await navigateToChat(page, "Elena Conti", null);
+  // Reaches here only if search path succeeded
+});
+```
+
+- [ ] **Step 4: Run suite**
+
+Run: `npm test`
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/commands.js test/navigate.test.js
+git commit -m "fix(navigate): wait up to 2s for chat grid before search fallback
+
+When the chat grid hasn't rendered yet (cold CDP connection, post-reload),
+isVisible() returned false immediately and the search fallback kicked in.
+For short or generic chat names, search matches many rows and picks the
+wrong one. Waiting up to 2s for the grid gives the primary, deterministic
+path a real chance before resorting to search."
+```
+
+---
+
+## Task 3: Propagate `--index` disambiguation into search fallback
+
+**Files:**
+- Modify: `lib/commands.js:56-95` (search fallback branch)
+
+- [ ] **Step 1: Write failing test**
+
+Append to `test/navigate.test.js`:
+
+```javascript
+test("search fallback supports --index when multiple exact matches", async () => {
+  // Two chats with identical name, only visible via search.
+  const searchAria = `
+- grid:
+    - row:
+      - gridcell "Ferragosto 10:00"
+    - row:
+      - gridcell "Ferragosto 11:30"
+`;
+  const page = makeFakePage({
+    gridVisibleAfterMs: 10000,
+    searchAria,
+    headerAria: 'button "Ferragosto"',
+  });
+
+  // Without --index, must throw with a disambiguation message:
+  await assert.rejects(
+    () => navigateToChat(page, "Ferragosto", null),
+    /Multiple chats named "Ferragosto" found/,
+  );
+
+  // With --index, must select the Nth result:
+  await navigateToChat(page, "Ferragosto", null, 2);
+});
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+Run: `node --test test/navigate.test.js`
+Expected: FAIL — current code picks the first match silently.
+
+- [ ] **Step 3: Apply disambiguation logic in search branch**
+
+Replace lines 72-90 of `lib/commands.js`. Current:
+
+```javascript
+  // Parse search results for exact name match
+  const searchAria = await page.locator(":root").ariaSnapshot();
+  const searchResults = parseSearchResults(searchAria, localeConfig);
+  const searchMatch = searchResults.find((c) => c.name === chatName);
+  if (!searchMatch) {
+    await page.keyboard.press("Escape");
+    await page.keyboard.press("Escape");
+    throw new Error(`Chat "${chatName}" not found (no exact match in search results)`);
+  }
+
+  const searchGrid = page.getByRole("grid").first();
+  const searchRow = searchGrid.getByRole("row").filter({
+    has: page.getByRole("gridcell", { name: searchMatch._gridcellLabel, exact: true }),
+  }).first();
+```
+
+New:
+
+```javascript
+  // Parse search results for exact name matches (may be >1)
+  const searchAria = await page.locator(":root").ariaSnapshot();
+  const searchResults = parseSearchResults(searchAria, localeConfig);
+  const searchMatches = searchResults.filter((c) => c.name === chatName);
+  if (searchMatches.length === 0) {
+    await page.keyboard.press("Escape");
+    await page.keyboard.press("Escape");
+    throw new Error(`Chat "${chatName}" not found (no exact match in search results)`);
+  }
+  if (searchMatches.length > 1 && index === undefined) {
+    const list = searchMatches.map((c, i) => `  ${i + 1}. ${c.name} (${c.time}) — ${c.lastMessage ?? ""}`).join("\n");
+    await page.keyboard.press("Escape");
+    await page.keyboard.press("Escape");
+    throw new Error(
+      `Multiple chats named "${chatName}" found:\n${list}\nUse --index N to select one (1-based).`,
+    );
+  }
+  if (searchMatches.length > 1 && (!Number.isInteger(index) || index < 1 || index > searchMatches.length)) {
+    await page.keyboard.press("Escape");
+    await page.keyboard.press("Escape");
+    throw new Error(`--index ${index} is out of range (${searchMatches.length} matches for "${chatName}")`);
+  }
+  const searchMatch = searchMatches.length > 1 ? searchMatches[index - 1] : searchMatches[0];
+
+  const searchGrid = page.getByRole("grid").first();
+  const searchRow = searchGrid.getByRole("row").filter({
+    has: page.getByRole("gridcell", { name: searchMatch._gridcellLabel, exact: true }),
+  }).first();
+```
+
+- [ ] **Step 4: Run test, confirm pass**
+
+Run: `node --test test/navigate.test.js`
+Expected: PASS.
+
+- [ ] **Step 5: Run full suite + smoke test**
+
+```bash
+npm test
+node greentap.js send "SomeRareName" "hello" --index 1  # sanity-check CLI still parses --index for send
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/commands.js test/navigate.test.js
+git commit -m "feat(navigate): support --index in search fallback
+
+Previously, if duplicate chat names existed only in search results
+(not in the visible chat list), the first match was silently chosen.
+Now duplicates raise the same disambiguation error as the grid path."
+```
+
+---
+
+## Release
+
+```bash
+git tag v0.3.3
+git push origin v0.3.3
+gh release create v0.3.3 \
+  --title "v0.3.3 — navigateToChat determinism" \
+  --notes "**Fixes**
+- Wait up to 2s for chat grid before falling back to search — eliminates non-deterministic routing on cold connections
+- \`--index N\` now works when duplicate chats appear only in search results (previously first match was silently chosen)"
+```

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -65,8 +65,7 @@ export async function navigateToChat(page, chatName, localeConfig, index = undef
   }
 
   // Fallback: search (handles archived chats and chats not in visible list).
-  // Note: --index disambiguation is not supported here — if duplicate names exist
-  // only in search results, the first match is used and a warning is logged.
+  // Supports --index disambiguation the same way the grid path does.
   const searchBox = page.getByRole("textbox").first();
   await searchBox.click();
   await humanDelay(300, 600);
@@ -80,15 +79,36 @@ export async function navigateToChat(page, chatName, localeConfig, index = undef
     throw new Error(`Chat "${chatName}" not found`);
   }
 
-  // Parse search results for exact name match
+  // Parse search results for exact name matches (may be >1)
   const searchAria = await page.locator(":root").ariaSnapshot();
   const searchResults = parseSearchResults(searchAria, localeConfig);
-  const searchMatch = searchResults.find((c) => c.name === chatName);
-  if (!searchMatch) {
+  const searchMatches = searchResults.filter((c) => c.name === chatName);
+  if (searchMatches.length === 0) {
     await page.keyboard.press("Escape");
     await page.keyboard.press("Escape");
     throw new Error(`Chat "${chatName}" not found (no exact match in search results)`);
   }
+  if (searchMatches.length > 1 && index === undefined) {
+    const list = searchMatches
+      .map((c, i) => `  ${i + 1}. ${c.name} (${c.time}) — ${c.lastMessage ?? ""}`)
+      .join("\n");
+    await page.keyboard.press("Escape");
+    await page.keyboard.press("Escape");
+    throw new Error(
+      `Multiple chats named "${chatName}" found:\n${list}\nUse --index N to select one (1-based).`,
+    );
+  }
+  if (
+    searchMatches.length > 1 &&
+    (!Number.isInteger(index) || index < 1 || index > searchMatches.length)
+  ) {
+    await page.keyboard.press("Escape");
+    await page.keyboard.press("Escape");
+    throw new Error(
+      `--index ${index} is out of range (${searchMatches.length} matches for "${chatName}")`,
+    );
+  }
+  const searchMatch = searchMatches.length > 1 ? searchMatches[index - 1] : searchMatches[0];
 
   const searchGrid = page.getByRole("grid").first();
   const searchRow = searchGrid.getByRole("row").filter({

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -25,9 +25,18 @@ export async function waitForMessagePanel(page) {
 
 export async function navigateToChat(page, chatName, localeConfig, index = undefined) {
   assertE2EAllowed(chatName);
-  // Try visible chat list first — parse aria for exact name match
+  // Try visible chat list first — parse aria for exact name match.
+  // Wait up to 2s for the grid to render before falling back to search.
+  // Without this wait, a freshly-opened daemon or post-reload state may see
+  // isVisible()=false even when the grid is about to paint, causing a spurious
+  // search fallback. For short/generic names (e.g. "Foot") that fallback can
+  // match many rows and silently pick the wrong chat.
   const chatGrid = page.getByRole("grid").first();
-  if (await chatGrid.isVisible().catch(() => false)) {
+  const gridReady = await chatGrid
+    .waitFor({ state: "visible", timeout: 2000 })
+    .then(() => true)
+    .catch(() => false);
+  if (gridReady) {
     const gridAria = await chatGrid.ariaSnapshot();
     const chats = parseChatList(gridAria, localeConfig);
     const matches = chats.filter((c) => c.name === chatName);

--- a/test/navigate.test.js
+++ b/test/navigate.test.js
@@ -1,0 +1,214 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import * as commands from "../lib/commands.js";
+
+/**
+ * Build a fake Playwright `page` that exercises navigateToChat end-to-end
+ * without a real browser. The fake page can delay grid visibility to
+ * simulate cold CDP connections where the chat grid hasn't painted yet.
+ *
+ * @param {object} opts
+ * @param {number} [opts.gridVisibleAfterMs=0] - Delay before the chat grid
+ *   reports visible. If gridVisibleAfterMs > the navigateToChat wait timeout,
+ *   the search fallback path runs.
+ * @param {string} [opts.gridAria=""] - ARIA snapshot returned by the chat grid
+ *   (used when grid path is taken).
+ * @param {string} [opts.searchAria=""] - ARIA snapshot returned by page.locator(":root")
+ *   AFTER search has been typed (used when fallback path is taken).
+ * @param {boolean} [opts.searchThrows=false] - If true, the search results
+ *   waitFor rejects, simulating "chat not found" in the search path.
+ */
+function makeFakePage({
+  gridVisibleAfterMs = 0,
+  gridAria = "",
+  searchAria = "",
+  searchThrows = false,
+} = {}) {
+  const started = Date.now();
+  const gridIsVisible = () => Date.now() - started >= gridVisibleAfterMs;
+  const calls = { gridClick: 0, searchClick: 0 };
+
+  const gridRow = {
+    filter: () => gridRow,
+    first: () => gridRow,
+    click: async () => {
+      calls.gridClick++;
+    },
+    isVisible: async () => true,
+    waitFor: async () => {
+      if (searchThrows) throw new Error("timeout waiting for search row");
+    },
+  };
+
+  const chatGrid = {
+    // The production code calls `.waitFor({ state, timeout })` on the grid
+    // before deciding grid-vs-search. This fake resolves iff the grid is
+    // visible by the deadline; otherwise throws (matching Playwright).
+    waitFor: async ({ timeout = 10000 } = {}) => {
+      const deadline = Date.now() + timeout;
+      while (Date.now() < deadline) {
+        if (gridIsVisible()) return;
+        await new Promise((r) => setTimeout(r, 20));
+      }
+      throw new Error("grid waitFor timeout");
+    },
+    isVisible: async () => gridIsVisible(),
+    ariaSnapshot: async () => gridAria,
+    getByRole: () => gridRow,
+    first: () => chatGrid,
+  };
+
+  // Compose textbox (inside contentinfo) — waitForMessagePanel uses this.
+  const composeTextbox = {
+    waitFor: async () => {},
+    click: async () => {},
+  };
+
+  // Sidebar search textbox — page.getByRole("textbox").first()
+  const searchTextbox = {
+    click: async () => {
+      calls.searchClick++;
+    },
+    first: () => searchTextbox,
+    waitFor: async () => {},
+  };
+
+  const contentinfo = {
+    getByRole: () => composeTextbox,
+  };
+
+  const page = {
+    getByRole: (role) => {
+      if (role === "grid") {
+        return { first: () => chatGrid };
+      }
+      if (role === "contentinfo") {
+        return contentinfo;
+      }
+      if (role === "textbox") {
+        return { first: () => searchTextbox };
+      }
+      if (role === "gridcell") {
+        return {};
+      }
+      return { first: () => ({ click: async () => {}, isVisible: async () => true }) };
+    },
+    locator: () => ({
+      ariaSnapshot: async () => searchAria,
+    }),
+    keyboard: {
+      type: async () => {},
+      press: async () => {},
+    },
+    _calls: calls,
+  };
+  return page;
+}
+
+// A complete grid ARIA snippet that parseChatList understands, with two
+// Ferragosto rows (different times) and one Elena Conti row for the
+// search-fallback duplicate test.
+const TWO_FERRAGOSTO_AND_ELENA = `- grid "Risultati della ricerca.":
+    - 'row "Ferragosto 10:00 Buongiorno"':
+      - 'gridcell "Ferragosto 10:00 Buongiorno"':
+        - img
+        - gridcell "Ferragosto 10:00"
+        - text: Buongiorno
+        - gridcell
+    - 'row "Ferragosto 11:30 A che ora?"':
+      - 'gridcell "Ferragosto 11:30 A che ora?"':
+        - img
+        - gridcell "Ferragosto 11:30"
+        - text: A che ora?
+        - gridcell
+    - 'row "Elena Conti 14:22 Ciao"':
+      - 'gridcell "Elena Conti 14:22 Ciao"':
+        - img
+        - gridcell "Elena Conti 14:22"
+        - text: Ciao
+        - gridcell
+  - contentinfo:
+    - textbox "Scrivi un messaggio"
+`;
+
+// Single Roberto Marini row — for grid-path determinism test.
+const ROBERTO_GRID = `- grid "Lista delle chat":
+    - 'row "Roberto Marini 12:34 Ciao"':
+      - 'gridcell "Roberto Marini 12:34 Ciao"':
+        - img
+        - gridcell "Roberto Marini 12:34"
+        - text: Ciao
+        - gridcell
+  - contentinfo:
+    - textbox "Scrivi un messaggio"
+`;
+
+describe("navigateToChat: grid determinism (waitFor gate)", () => {
+  it("uses grid path when grid becomes visible within the wait window", async () => {
+    const page = makeFakePage({
+      gridVisibleAfterMs: 300, // well under the 2s wait
+      gridAria: ROBERTO_GRID,
+    });
+    // If grid path is taken, gridRow.click is called; search path would
+    // call searchTextbox.click instead.
+    await commands.navigateToChat(page, "Roberto Marini", null);
+    assert.equal(page._calls.gridClick, 1, "should have clicked a grid row");
+    assert.equal(page._calls.searchClick, 0, "should NOT have fallen back to search");
+  });
+
+  it("falls back to search when grid never becomes visible within wait window", async () => {
+    const page = makeFakePage({
+      gridVisibleAfterMs: 10_000, // exceeds any reasonable wait
+      gridAria: "",
+      searchAria: TWO_FERRAGOSTO_AND_ELENA,
+    });
+    await commands.navigateToChat(page, "Elena Conti", null);
+    assert.equal(page._calls.searchClick, 1, "should have fallen back to search");
+  });
+});
+
+describe("navigateToChat: --index disambiguation in search fallback", () => {
+  it("throws with disambiguation message when multiple exact matches in search results and no --index", async () => {
+    const page = makeFakePage({
+      gridVisibleAfterMs: 10_000, // force search path
+      searchAria: TWO_FERRAGOSTO_AND_ELENA,
+    });
+    await assert.rejects(
+      () => commands.navigateToChat(page, "Ferragosto", null),
+      (err) => {
+        assert.ok(
+          /Multiple chats named "Ferragosto" found/.test(err.message),
+          `expected disambiguation message, got: ${err.message}`,
+        );
+        assert.ok(err.message.includes("--index"), "expected --index hint in message");
+        assert.ok(err.message.includes("1."), "expected listing index 1");
+        assert.ok(err.message.includes("2."), "expected listing index 2");
+        return true;
+      },
+    );
+  });
+
+  it("selects the Nth result when --index is provided in search fallback", async () => {
+    const page = makeFakePage({
+      gridVisibleAfterMs: 10_000,
+      searchAria: TWO_FERRAGOSTO_AND_ELENA,
+    });
+    await assert.doesNotReject(
+      () => commands.navigateToChat(page, "Ferragosto", null, 2),
+    );
+  });
+
+  it("throws out-of-range error when --index exceeds match count in search fallback", async () => {
+    const page = makeFakePage({
+      gridVisibleAfterMs: 10_000,
+      searchAria: TWO_FERRAGOSTO_AND_ELENA,
+    });
+    await assert.rejects(
+      () => commands.navigateToChat(page, "Ferragosto", null, 99),
+      (err) => {
+        assert.ok(/out of range/.test(err.message), `expected out-of-range error, got: ${err.message}`);
+        return true;
+      },
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Eliminates non-deterministic behavior in `navigateToChat`. When the chat grid hadn't rendered yet, `isVisible()` returned false immediately → search fallback → short names like `"Foot"` matched many chats and picked the wrong one.

Now: wait up to 2s for the grid before falling back to search. Search path also supports `--index N` disambiguation (previously first duplicate silently won).

Plan: [`docs/superpowers/plans/2026-04-22-navigatetochat-robustness.md`](docs/superpowers/plans/2026-04-22-navigatetochat-robustness.md)

## Commits (3)

1. `docs: add navigateToChat robustness implementation plan`
2. `fix(navigate): wait up to 2s for chat grid before search fallback`
3. `feat(navigate): support --index in search fallback`

## Tests

`npm test`: 89 passing, 0 failing (+5 new `test/navigate.test.js` tests using fake page doubles — no browser).

## Review findings

- `/review-code`: no blockers. Advisories: triple-Escape cleanup could be extracted to a helper; `navigateToChat` grew ~25 lines (plan hinted at extracting to `lib/navigate.js` — deferred to keep diff minimal).
- `/review-security`: no blockers. Advisories: the 2s timeout could be a named constant; pre-existing `lastMessage` leak into stderr on disambiguation (not a regression, worth a follow-up).

## Plan deviations

None — all changes localized to `navigateToChat` for minimal merge conflict surface with the parallel link + image PRs.

## Test plan

- [ ] Reproduce the "Foot" bug on the pre-fix build (optional sanity check)
- [ ] Confirm `read "Foot"` opens the intended chat deterministically on the fix
- [ ] Confirm `--index 2` works for archived duplicates that only appear via search