### PR TITLE
feat: image download + agent-readable paths (fetch-images command)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ node greentap.js chats [--json]      # List all chats
 node greentap.js unread [--json]     # List unread chats
 node greentap.js read <chat> [--json] [--scroll] # Read messages from a chat
 node greentap.js poll-results <chat> [--json]  # Get most recent poll question + vote counts
+node greentap.js fetch-images <chat> [--limit N] [--json] # Download recent images to ~/.greentap/downloads/<chat-slug>/
 node greentap.js send <chat> <msg>   # Send a message
 node greentap.js search <q> [--json] # Search chats
 node greentap.js snapshot [SCOPE]    # Dump aria snapshot (full|chats|messages|compose)

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ node greentap.js read "Family" --scroll --json
 # Send a message
 node greentap.js send "Family" "Hello from the terminal"
 
+# Download recent images from a chat to ~/.greentap/downloads/<chat-slug>/
+node greentap.js fetch-images "Family" --limit 5 --json
+
 # Search for a contact or group (finds archived chats too)
 node greentap.js search "John" --json
 

--- a/docs/superpowers/plans/2026-04-22-image-download.md
+++ b/docs/superpowers/plans/2026-04-22-image-download.md
@@ -1,0 +1,538 @@
+# Image Download Implementation Plan (priority #1)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let agents *see* images sent in WhatsApp chats. Download visible images from a chat to local files, surface the paths in `read` output, and update SKILL.md so Claude (multimodal) reads them back for content understanding.
+
+**Architecture:** Two-layer approach.
+- **Layer 1 (visibility):** extend the parser to mark image messages with an `imageId` (stable hash of blob URL) in the existing `read` output. No download yet — agents can see "there are 3 images in this window".
+- **Layer 2 (materialization):** new `greentap fetch-images <chat>` command. In-page `fetch(blobUrl)` → base64 → write to `~/.greentap/downloads/<chat-slug>/<imageId>.<ext>`. Returns JSON `[{imageId, path, messageTime}]`. Agents then `Read` each path; Claude's multimodal pipeline handles the rest.
+
+**Tech Stack:** Playwright `page.evaluate` for blob extraction, Node `fs` for file write, aria snapshot for `img` role detection.
+
+**Scope boundaries (YAGNI):**
+- Images only — not videos, not voice notes, not documents. (Voice is Phase 8 of ROADMAP; videos are a follow-up plan.)
+- Thumbnail resolution (what's rendered in chat) — not full-res. Full-res requires clicking through the viewer; do as follow-up if content quality is insufficient.
+- No OCR in greentap — that's Claude's job once the file is in context.
+
+---
+
+## Context you need
+
+- Source issue: broader "polls + file/image download" ask. Polls are already covered by `poll-results` (v0.3.0); this plan targets the image-download half.
+- Existing patterns to reuse:
+  - `lib/commands.js:97-99` — `chats()` shape: single aria snapshot → `parseChatList()`. Follow the same "take snapshot, parse, return JSON" split for images.
+  - `lib/parser.js` — parsing is pure, fixture-tested. Add an `"image"` kind alongside whatever text messages return today. Read the current `parseMessages` to find the row-walking logic before adding image support.
+  - `lib/commands.js:138-165` — `findLoadMoreButton` shows the `page.evaluate` DOM-walking pattern you'll reuse for image blob extraction.
+- WhatsApp Web image representation (verify in Task 1 before coding):
+  - Message bubble contains an `<img>` with `src="blob:https://web.whatsapp.com/<uuid>"` for the thumbnail.
+  - Aria snapshot typically exposes this as `img "Photo"` or locale-specific label (e.g. `"Foto"` in Italian).
+  - Full-screen viewer has a download button but this plan uses in-DOM blob extraction (simpler, no UI interaction).
+- Public repo: all fixtures MUST use fake data. No real images; Task 1 records a fixture from a test chat with only fake/public-domain images, or a synthetic fixture edited by hand.
+
+## File Structure
+
+- Create: `~/.greentap/downloads/<chat-slug>/` (runtime, gitignored — user-local cache)
+- Create: `test/fixtures/image-messages.snapshot.txt` — fake aria snapshot with image messages (hand-edited to remove PII)
+- Modify: `lib/parser.js` — add image kind handling in `parseMessages`
+- Modify: `lib/commands.js` — new exported `fetchImages(page, chatName, options)`
+- Modify: `greentap.js` — wire `fetch-images` subcommand with argv parsing
+- Modify: `test/parser.test.js` — fixture tests for image detection
+- Modify: `.claude/skills/greentap/SKILL.md` — document image workflow for agents
+- Modify: `README.md` — add `fetch-images` to command list
+
+---
+
+## Task 1: Exploration — capture image aria snapshot
+
+**Files:**
+- Create: `test/fixtures/image-messages.snapshot.txt`
+- Create: `scripts/capture-image-snapshot.mjs` (throwaway, not committed)
+
+- [ ] **Step 1: Set up a test chat**
+
+Send 2 images to *yourself* on WhatsApp (Note to Self chat, or a dedicated test chat). Use images with no PII — public-domain photos or synthetic gradients. This chat is the source of truth for the fixture.
+
+- [ ] **Step 2: Capture the aria snapshot**
+
+Run:
+
+```bash
+node greentap.js snapshot messages
+```
+
+Copy the output. Identify the lines that represent image messages — look for `img`, `"Photo"`, `"Foto"`, or image-like ARIA roles.
+
+- [ ] **Step 3: Inspect the DOM directly**
+
+Open a devtools-friendly one-shot script. Create `scripts/capture-image-snapshot.mjs` (not committed):
+
+```javascript
+import { connect } from "../lib/client.js";
+import { navigateToChat } from "../lib/commands.js";
+
+const { page, localeConfig, disconnect } = await connect();
+try {
+  await navigateToChat(page, "<Your Test Chat>", localeConfig);
+  const info = await page.evaluate(() => {
+    const msgRows = [...document.querySelectorAll('[role="row"]')]
+      .filter(r => !r.closest('[role="grid"]'));
+    return msgRows.slice(-10).map(r => {
+      const img = r.querySelector('img');
+      return img ? {
+        alt: img.alt,
+        src: img.src.slice(0, 60),
+        width: img.naturalWidth,
+        parentRoleText: r.getAttribute('aria-label')?.slice(0, 60),
+      } : null;
+    }).filter(Boolean);
+  });
+  console.log(JSON.stringify(info, null, 2));
+} finally {
+  await disconnect();
+}
+```
+
+Run: `node scripts/capture-image-snapshot.mjs`
+Expected output: JSON listing image `src` (confirms `blob:` URL), `naturalWidth` (confirms non-zero for loaded thumbs), `alt`, and row `aria-label`.
+
+Record findings in a scratch note (not committed). Decide: is the primary detection marker `img[alt]`, the row `aria-label`, or an attribute? Pick the most stable (expect `img.src.startsWith("blob:")` to be reliable).
+
+- [ ] **Step 4: Sanitize + save a fixture**
+
+Take the `snapshot messages` output from Step 2. Hand-edit to:
+- Replace any real names with fake personas (use existing: Roberto Marini, Elena Conti, Famiglia Rossi)
+- Replace any real timestamps with plausible fake ones
+- Keep the structural image markers untouched
+
+Save as `test/fixtures/image-messages.snapshot.txt`.
+
+- [ ] **Step 5: Delete the throwaway script**
+
+```bash
+rm scripts/capture-image-snapshot.mjs
+```
+
+No commit yet — Task 2 ships the parser change + the fixture together.
+
+---
+
+## Task 2: Parser — detect image messages
+
+**Files:**
+- Modify: `lib/parser.js`
+- Modify: `test/parser.test.js`
+- Add: `test/fixtures/image-messages.snapshot.txt` (from Task 1)
+
+- [ ] **Step 1: Write failing parser test**
+
+Append to `test/parser.test.js`:
+
+```javascript
+import { readFileSync } from "node:fs";
+import { parseMessages } from "../lib/parser.js";
+
+test("parseMessages flags image messages with kind='image'", () => {
+  const snapshot = readFileSync("test/fixtures/image-messages.snapshot.txt", "utf8");
+  const messages = parseMessages(snapshot, { localeConfig: { /* fixture matches IT locale */ dayNames: [], yesterday: "Ieri" } });
+  const images = messages.filter(m => m.kind === "image");
+  assert.ok(images.length >= 1, "expected at least one image message in fixture");
+  for (const img of images) {
+    assert.ok(img.imageId, "image must have imageId");
+    assert.ok(img.sender, "image must have sender");
+    assert.ok(img.time, "image must have time");
+  }
+});
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+Run: `node --test test/parser.test.js`
+Expected: FAIL — `parseMessages` does not currently emit `kind: "image"`.
+
+- [ ] **Step 3: Implement image detection in parser**
+
+Read `lib/parser.js` in full first. Locate `parseMessages` and its per-row loop. Without rewriting the function, add a branch: *after* determining sender/time for a row, detect whether the row contains an `img` marker. ARIA snapshot syntax uses `- img "<label>"` lines.
+
+Pseudocode (adapt to the real structure — do not skip reading the current code):
+
+```javascript
+// Inside per-row processing in parseMessages, after text extraction:
+const imgMatch = rowBlock.match(/^\s*-\s+img\s+"([^"]*)"/m);
+if (imgMatch) {
+  // imageId is a stable hash of (sender + time + alt + rowIndex) so the same
+  // image in the same position produces the same id across reads.
+  const raw = `${sender}|${time}|${imgMatch[1]}|${rowIndex}`;
+  const imageId = simpleHash(raw);  // add simpleHash below if not already in parser.js
+  result.push({ kind: "image", sender, time, timestamp, imageId, altText: imgMatch[1] });
+  continue;  // don't also emit as text
+}
+```
+
+And add `simpleHash` if parser.js does not already expose one:
+
+```javascript
+function simpleHash(str) {
+  let h = 0;
+  for (let i = 0; i < str.length; i++) {
+    h = (Math.imul(31, h) + str.charCodeAt(i)) | 0;
+  }
+  return (h >>> 0).toString(16).padStart(8, "0");
+}
+```
+
+Non-image messages should keep `kind: "text"` (or whatever the current default is — align with the existing shape; if there is no `kind` field today, introduce it on all outputs for consistency, and update existing fixture tests to assert it).
+
+- [ ] **Step 4: Run parser tests, confirm pass**
+
+Run: `node --test test/parser.test.js`
+Expected: PASS for new test; existing tests still pass after `kind` field added to their expectations.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/parser.js test/parser.test.js test/fixtures/image-messages.snapshot.txt
+git commit -m "feat(parser): detect image messages with kind='image'+imageId
+
+Marks messages whose ARIA row contains 'img \"<alt>\"' with
+kind:\"image\" and a stable imageId (hash of sender+time+alt+index).
+Enables downstream fetch-images command and surfaces image presence
+in read output."
+```
+
+---
+
+## Task 3: `fetchImages` command — in-DOM blob → file
+
+**Files:**
+- Modify: `lib/commands.js` — add `fetchImages` export
+- Create: `test/fetch-images.test.js` — fake-page unit test for slug + path logic (pure-ish)
+
+- [ ] **Step 1: Write failing test (pure helpers)**
+
+Create `test/fetch-images.test.js`:
+
+```javascript
+import { test } from "node:test";
+import assert from "node:assert";
+import { slugifyChat, imageFilename } from "../lib/commands.js";
+
+test("slugifyChat produces filesystem-safe names", () => {
+  assert.strictEqual(slugifyChat("Famiglia Rossi"), "famiglia-rossi");
+  assert.strictEqual(slugifyChat("Work / Team"), "work-team");
+  assert.strictEqual(slugifyChat("  Spaces  "), "spaces");
+});
+
+test("imageFilename uses imageId + ext guess", () => {
+  assert.strictEqual(imageFilename({ imageId: "abc12345" }, "image/jpeg"), "abc12345.jpg");
+  assert.strictEqual(imageFilename({ imageId: "abc12345" }, "image/png"),  "abc12345.png");
+  assert.strictEqual(imageFilename({ imageId: "abc12345" }, undefined),    "abc12345.bin");
+});
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+Run: `node --test test/fetch-images.test.js`
+Expected: FAIL — helpers not exported.
+
+- [ ] **Step 3: Implement helpers + `fetchImages`**
+
+Add to `lib/commands.js`:
+
+```javascript
+import { writeFileSync, mkdirSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+
+const DOWNLOADS_DIR = join(homedir(), ".greentap", "downloads");
+
+export function slugifyChat(name) {
+  return name
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+const MIME_EXT = { "image/jpeg": "jpg", "image/png": "png", "image/webp": "webp", "image/gif": "gif" };
+export function imageFilename(msg, mimeType) {
+  return `${msg.imageId}.${MIME_EXT[mimeType] ?? "bin"}`;
+}
+
+/**
+ * Download images from the currently-visible messages of <chatName>.
+ * Returns [{ imageId, path, sender, time, timestamp }].
+ * Only downloads images not already cached (path exists → skip the fetch).
+ */
+export async function fetchImages(page, chatName, { localeConfig, index, limit = 20 } = {}) {
+  await navigateToChat(page, chatName, localeConfig, index);
+
+  // 1. Parse aria to identify image messages + their order.
+  const aria = await page.locator(":root").ariaSnapshot();
+  const allMsgs = parseMessages(aria, { localeConfig });
+  const images = allMsgs.filter((m) => m.kind === "image").slice(-limit);
+  if (images.length === 0) return [];
+
+  // 2. Collect blob payloads in-page. We walk img elements in message rows
+  //    (outside the grid chat list) in DOM order; the Nth image found
+  //    corresponds to the Nth image row in the aria snapshot.
+  const payloads = await page.evaluate(async (count) => {
+    const rows = [...document.querySelectorAll('[role="row"]')].filter((r) => !r.closest('[role="grid"]'));
+    const imgs = [];
+    for (const row of rows) {
+      const img = row.querySelector("img");
+      if (img && img.src && img.src.startsWith("blob:")) imgs.push(img);
+    }
+    const targets = imgs.slice(-count);
+    const out = [];
+    for (const img of targets) {
+      try {
+        const resp = await fetch(img.src);
+        const blob = await resp.blob();
+        const buf = new Uint8Array(await blob.arrayBuffer());
+        // Chunked base64 to avoid call-stack limits on large images
+        let binary = "";
+        const chunk = 0x8000;
+        for (let i = 0; i < buf.length; i += chunk) {
+          binary += String.fromCharCode.apply(null, buf.subarray(i, i + chunk));
+        }
+        out.push({ mimeType: blob.type, base64: btoa(binary) });
+      } catch (err) {
+        out.push({ error: err.message });
+      }
+    }
+    return out;
+  }, images.length);
+
+  // 3. Write files
+  const chatDir = join(DOWNLOADS_DIR, slugifyChat(chatName));
+  mkdirSync(chatDir, { recursive: true });
+
+  const results = [];
+  for (let i = 0; i < images.length; i++) {
+    const msg = images[i];
+    const payload = payloads[i];
+    if (!payload || payload.error) {
+      results.push({ imageId: msg.imageId, error: payload?.error ?? "no payload" });
+      continue;
+    }
+    const filename = imageFilename(msg, payload.mimeType);
+    const path = join(chatDir, filename);
+    writeFileSync(path, Buffer.from(payload.base64, "base64"), { mode: 0o600 });
+    results.push({
+      imageId: msg.imageId,
+      path,
+      sender: msg.sender,
+      time: msg.time,
+      timestamp: msg.timestamp,
+      mimeType: payload.mimeType,
+    });
+  }
+  return results;
+}
+```
+
+- [ ] **Step 4: Run helper test, confirm pass**
+
+Run: `node --test test/fetch-images.test.js`
+Expected: PASS.
+
+- [ ] **Step 5: Manual smoke test**
+
+```bash
+node -e "
+  (async () => {
+    const { connect } = await import('./lib/client.js');
+    const { fetchImages } = await import('./lib/commands.js');
+    const { page, localeConfig, disconnect } = await connect();
+    try {
+      const out = await fetchImages(page, '<Your Test Chat>', { localeConfig, limit: 5 });
+      console.log(JSON.stringify(out, null, 2));
+    } finally { await disconnect(); }
+  })();
+"
+ls -lh ~/.greentap/downloads/*/
+file ~/.greentap/downloads/*/*.*
+```
+
+Expected: JSON output lists local paths; `file` confirms JPEG/PNG/WebP.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/commands.js test/fetch-images.test.js
+git commit -m "feat(commands): add fetchImages — in-DOM blob → ~/.greentap/downloads
+
+Walks image-kind messages in a chat, fetches each blob URL from inside
+the page context, base64-encodes the bytes, and writes them to a
+chat-scoped directory. Returns [{imageId, path, sender, time, ...}]."
+```
+
+---
+
+## Task 4: CLI — `greentap fetch-images`
+
+**Files:**
+- Modify: `greentap.js` — subcommand wiring
+- Modify: `test/cli.test.js` — argv parsing test
+
+- [ ] **Step 1: Write failing CLI arg-parsing test**
+
+Append to `test/cli.test.js` (match its existing pattern — read the file first):
+
+```javascript
+test("fetch-images parses chat name + --limit + --index", () => {
+  const argv = ["fetch-images", "Famiglia Rossi", "--limit", "3", "--index", "2"];
+  const parsed = parseArgs(argv);  // or whatever helper the file already uses
+  assert.strictEqual(parsed.command, "fetch-images");
+  assert.strictEqual(parsed.chat, "Famiglia Rossi");
+  assert.strictEqual(parsed.limit, 3);
+  assert.strictEqual(parsed.index, 2);
+});
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+Run: `node --test test/cli.test.js`
+Expected: FAIL — command not registered.
+
+- [ ] **Step 3: Wire subcommand in `greentap.js`**
+
+Read `greentap.js` to learn the existing dispatch style. Add a case that:
+- Accepts `fetch-images <chat>` with `--limit N` (default 20), `--index N`, `--json` (default: human)
+- Calls `fetchImages(page, chat, { localeConfig, index, limit })`
+- Prints either JSON (when `--json`) or one line per result: `<time> <sender> → <path>`
+
+Pseudocode addition (adapt to the real dispatcher):
+
+```javascript
+case "fetch-images": {
+  const chat = positional[0];
+  if (!chat) { console.error("usage: greentap fetch-images <chat> [--limit N] [--index N] [--json]"); process.exit(2); }
+  const { page, localeConfig, disconnect } = await connect();
+  try {
+    const out = await fetchImages(page, chat, { localeConfig, index: flags.index, limit: flags.limit ?? 20 });
+    if (flags.json) {
+      console.log(JSON.stringify(out, null, 2));
+    } else {
+      for (const r of out) {
+        if (r.error) console.log(`ERROR ${r.imageId}: ${r.error}`);
+        else console.log(`${r.time} ${r.sender} → ${r.path}`);
+      }
+    }
+  } finally { await disconnect(); }
+  break;
+}
+```
+
+- [ ] **Step 4: Run CLI tests, confirm pass**
+
+Run: `node --test test/cli.test.js`
+Expected: PASS.
+
+- [ ] **Step 5: Manual smoke**
+
+```bash
+node greentap.js fetch-images "<Your Test Chat>" --limit 3 --json
+```
+
+- [ ] **Step 6: Update README**
+
+Edit `README.md` commands section — add:
+
+```markdown
+| `fetch-images <chat> [--limit N] [--json]` | Download recent images to `~/.greentap/downloads/<chat-slug>/` |
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add greentap.js test/cli.test.js README.md
+git commit -m "feat(cli): add fetch-images subcommand"
+```
+
+---
+
+## Task 5: Skill surface — SKILL.md
+
+**Files:**
+- Modify: `.claude/skills/greentap/SKILL.md`
+
+- [ ] **Step 1: Read existing SKILL.md**
+
+Read the current file end-to-end. Identify the section that enumerates commands and the section that explains workflows for agents.
+
+- [ ] **Step 2: Add an "Images" workflow block**
+
+Append:
+
+```markdown
+## Reading images from a chat
+
+Images in `read --json` output appear with `kind: "image"` and an `imageId`
+but no inline content. To actually view them:
+
+1. Call `greentap fetch-images <chat> [--limit N] --json`
+2. Each returned item has a `path` (absolute, under `~/.greentap/downloads/`)
+3. Use the **Read** tool on that path — the image is handed to Claude as a
+   multimodal input. Describe, OCR, or reason about it directly.
+
+Example:
+
+    $ greentap fetch-images "Famiglia Rossi" --limit 3 --json
+    [
+      {
+        "imageId": "a7f3c211",
+        "path": "/Users/<you>/.greentap/downloads/famiglia-rossi/a7f3c211.jpg",
+        "sender": "Elena Conti",
+        "time": "14:22",
+        "timestamp": "2026-04-22T14:22:00"
+      }
+    ]
+
+After reading, delete the file if no longer needed — these are cached but
+not auto-pruned:
+
+    rm ~/.greentap/downloads/famiglia-rossi/a7f3c211.jpg
+
+Limitations:
+- Thumbnail resolution only (what's rendered in the chat). Full-resolution
+  download via the viewer is a future enhancement.
+- Does not fetch images from chats you haven't scrolled to — only images
+  currently in the DOM. Scroll the chat first if needed.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude/skills/greentap/SKILL.md
+git commit -m "docs(skill): document image fetch + multimodal read workflow"
+```
+
+---
+
+## Release
+
+```bash
+git tag v0.4.0
+git push origin v0.4.0
+gh release create v0.4.0 \
+  --title "v0.4.0 — Image download" \
+  --notes "**New**
+- \`greentap fetch-images <chat>\` — downloads currently-visible images from a chat to \`~/.greentap/downloads/<chat-slug>/\`
+- \`read\` output now marks image messages with \`kind: \"image\"\` and an \`imageId\`
+- SKILL.md updated with the Read-to-multimodal agent workflow
+
+**Known limits**
+- Thumbnail resolution only — full-res via viewer is follow-up work
+- Polls / voice / video / documents not yet supported"
+```
+
+---
+
+## Follow-ups (separate plans, not this one)
+
+- **Full-resolution images** — click into the WhatsApp viewer and intercept the Playwright `download` event. Pros: full quality. Cons: steals UI focus; needs a way to close the viewer cleanly.
+- **Voice note transcription** — Phase 8 in `ROADMAP.md`. Requires audio blob extraction + Whisper.
+- **Document / file download** — same blob pattern but extension detection is trickier; PDFs need `Content-Disposition` heuristics.
+- **Auto-prune cache** — rotate `~/.greentap/downloads/` (e.g. delete files older than 7d) on daemon shutdown.

--- a/greentap.js
+++ b/greentap.js
@@ -10,6 +10,7 @@
  *   greentap unread [--json]    — List unread chats
  *   greentap read <chat> [--json] [--scroll] [--index N] — Read messages from a chat
  *   greentap send <chat> <message> [--index N] — Send a message to a chat
+ *   greentap fetch-images <chat> [--limit N] [--index N] [--json] — Download recent images
  *   greentap search <query> [--json] — Search chats
  *   greentap snapshot [SCOPE] [--chat NAME] — Dump raw aria snapshot
  *   greentap e2e                — Run round-trip verification against sandbox (GREENTAP_E2E=1)
@@ -103,6 +104,28 @@ async function cmdRead(chatName, json, scroll, index) {
 
 async function cmdSend(chatName, message, index) {
   await withDaemon((page, localeConfig) => commands.send(page, chatName, message, localeConfig, index));
+}
+
+async function cmdFetchImages(chatName, json, limit, index) {
+  const result = await withDaemon((page, localeConfig) =>
+    commands.fetchImages(page, chatName, { localeConfig, index, limit })
+  );
+  if (json) {
+    console.log(JSON.stringify(result));
+    return;
+  }
+  if (result.length === 0) {
+    console.log("No images found in the visible chat window.");
+    return;
+  }
+  for (const r of result) {
+    if (r.error) {
+      console.log(`ERROR ${r.imageId}: ${r.error}`);
+    } else {
+      const sender = r.sender || "";
+      console.log(`${r.time} ${sender} → ${r.path}`);
+    }
+  }
 }
 
 async function cmdPollResults(chatName, json, index) {
@@ -229,6 +252,25 @@ try {
       await cmdSend(sendArgs[0], sendArgs.slice(1).join(" "), sendIndex);
       break;
     }
+    case "fetch-images": {
+      const fiRaw = args.slice(1);
+      const fiIndexIdx = fiRaw.indexOf("--index");
+      const fiLimitIdx = fiRaw.indexOf("--limit");
+      const fiIndex = fiIndexIdx >= 0 ? parseInt(fiRaw[fiIndexIdx + 1], 10) : undefined;
+      const fiLimit = fiLimitIdx >= 0 ? parseInt(fiRaw[fiLimitIdx + 1], 10) : undefined;
+      const fiChat = fiRaw.filter((a, i) => {
+        if (a === "--json" || a === "--limit" || a === "--index") return false;
+        if (fiIndexIdx >= 0 && i === fiIndexIdx + 1) return false;
+        if (fiLimitIdx >= 0 && i === fiLimitIdx + 1) return false;
+        return true;
+      })[0];
+      if (!fiChat) {
+        console.error("Usage: greentap fetch-images <chat> [--limit N] [--index N] [--json]");
+        process.exit(1);
+      }
+      await cmdFetchImages(fiChat, args.includes("--json"), fiLimit, fiIndex);
+      break;
+    }
     case "poll-results": {
       const prIndexIdx = args.indexOf("--index");
       const prIndex = prIndexIdx >= 0 ? parseInt(args[prIndexIdx + 1], 10) : undefined;
@@ -289,6 +331,8 @@ Commands:
   read <chat> [--json] [--scroll] [--index N]  Read messages from a chat
   send <chat> <message> [--index N]            Send a message to a chat
   poll-results <chat> [--json] [--index N]     Get most recent poll results
+  fetch-images <chat> [--limit N] [--index N] [--json]
+                                               Download recent images from a chat
   search <query> [--json]                      Search chats
   snapshot [SCOPE] [--chat NAME]               Dump aria snapshot (full|chats|messages|compose)
   e2e                                          Run round-trip verification (GREENTAP_E2E=1 required)

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -6,8 +6,50 @@
  * instead of locale-specific labels.
  */
 
+import { writeFileSync, mkdirSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
 import { parseChatList, parseMessages, parseSearchResults, parsePollMessages } from "./parser.js";
 import { assertE2EAllowed, filterToSandbox, isE2EMode } from "./e2e-guard.js";
+
+/** Downloads cache root. Per-chat subdir, 0o600 file mode — user-local only. */
+const DOWNLOADS_DIR = join(homedir(), ".greentap", "downloads");
+
+/** Known image mime → file extension mapping. Fallback is ".bin". */
+const MIME_EXT = {
+  "image/jpeg": "jpg",
+  "image/png": "png",
+  "image/webp": "webp",
+  "image/gif": "gif",
+};
+
+/**
+ * Convert a chat name into a filesystem-safe slug.
+ * Lowercases, replaces any non-alphanumeric run with a hyphen, and trims
+ * leading/trailing hyphens. Returns "" if the input has no alphanumerics.
+ * Exported for unit testing.
+ * @param {string} name
+ * @returns {string}
+ */
+export function slugifyChat(name) {
+  return name
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/**
+ * Build a filename for a downloaded image.
+ * Uses the message's imageId as basename and maps mime type to extension.
+ * Exported for unit testing.
+ * @param {{imageId: string}} msg
+ * @param {string|undefined} mimeType
+ * @returns {string}
+ */
+export function imageFilename(msg, mimeType) {
+  return `${msg.imageId}.${MIME_EXT[mimeType] ?? "bin"}`;
+}
 
 function humanDelay(min = 200, max = 500) {
   const ms = Math.floor(Math.random() * (max - min + 1)) + min;
@@ -444,6 +486,133 @@ export async function search(page, query, localeConfig) {
   await page.keyboard.press("Escape");
 
   return filterToSandbox(parseSearchResults(aria, localeConfig));
+}
+
+/**
+ * Download currently-visible images from a chat to local files.
+ *
+ * Navigates to <chatName>, parses the aria snapshot for image-kind messages,
+ * and extracts each image blob in-page via `fetch(blobUrl)` → base64 → file.
+ * Files land at ~/.greentap/downloads/<chat-slug>/<imageId>.<ext> with 0o600
+ * mode.
+ *
+ * Returns one result per image-message, in DOM order:
+ * `[{ imageId, path, sender, time, timestamp, mimeType }]`.
+ * Failed downloads surface as `{ imageId, error }`.
+ *
+ * @param {import("playwright").Page} page
+ * @param {string} chatName
+ * @param {object} [options]
+ * @param {object} [options.localeConfig]
+ * @param {number} [options.index] - 1-based disambiguation for duplicate names
+ * @param {number} [options.limit=20] - Cap on images fetched (most recent)
+ * @returns {Promise<Array<object>>}
+ */
+export async function fetchImages(page, chatName, { localeConfig, index, limit = 20 } = {}) {
+  assertE2EAllowed(chatName);
+  await navigateToChat(page, chatName, localeConfig, index);
+
+  // 1. Parse aria to identify image messages + their order within the row area.
+  const aria = await page.locator(":root").ariaSnapshot();
+  const allMsgs = parseMessages(aria, { localeConfig });
+  const images = allMsgs.filter((m) => m.kind === "image").slice(-limit);
+  if (images.length === 0) return [];
+
+  // 2. Collect blob payloads in-page. We walk img elements in message rows
+  //    (rows NOT inside the chat-list grid) in DOM order. Each `button`
+  //    containing 2+ `<img>` children is one "image message" in the parser;
+  //    we take one img per such button, picking the first loaded thumbnail.
+  //    The Nth image-button in DOM order corresponds to the Nth image-kind
+  //    message emitted by parseMessages, so ordering is preserved.
+  const payloads = await page.evaluate(async (count) => {
+    // Helper: find the effective blob: URL for an image element.
+    // WhatsApp sometimes defers the src onto the <img> after load; fall back
+    // to the closest ancestor with background-image: url("blob:...") if
+    // needed.
+    function resolveBlobUrl(img) {
+      if (img.src && img.src.startsWith("blob:")) return img.src;
+      let el = img;
+      while (el) {
+        const bg = getComputedStyle(el).backgroundImage;
+        const m = bg && bg.match(/url\("?(blob:[^"'\)]+)/);
+        if (m) return m[1];
+        el = el.parentElement;
+      }
+      return null;
+    }
+
+    // Rows outside the chat-list grid = message rows.
+    const rows = Array.from(document.querySelectorAll('[role="row"]'))
+      .filter((r) => !r.closest('[role="grid"]'));
+
+    // For each image-button in DOM order, pick its first <img> child.
+    const imageTargets = [];
+    for (const row of rows) {
+      const buttons = row.querySelectorAll(":scope button");
+      for (const btn of buttons) {
+        const imgs = btn.querySelectorAll(":scope > img");
+        if (imgs.length < 2) continue;
+        // Pick the first img that has a resolvable blob URL.
+        for (const img of imgs) {
+          const url = resolveBlobUrl(img);
+          if (url) { imageTargets.push(url); break; }
+        }
+      }
+    }
+
+    // Match parser slice(-count) semantics: keep the most recent `count`.
+    const targets = imageTargets.slice(-count);
+
+    const out = [];
+    for (const url of targets) {
+      try {
+        const resp = await fetch(url);
+        if (!resp.ok) {
+          out.push({ error: `fetch status ${resp.status}` });
+          continue;
+        }
+        const blob = await resp.blob();
+        const buf = new Uint8Array(await blob.arrayBuffer());
+        // Chunked base64 to avoid String.fromCharCode.apply stack limits
+        // on large thumbnails.
+        let binary = "";
+        const chunk = 0x8000;
+        for (let i = 0; i < buf.length; i += chunk) {
+          binary += String.fromCharCode.apply(null, buf.subarray(i, i + chunk));
+        }
+        out.push({ mimeType: blob.type, base64: btoa(binary) });
+      } catch (err) {
+        out.push({ error: err && err.message ? err.message : String(err) });
+      }
+    }
+    return out;
+  }, images.length);
+
+  // 3. Write files. Chat-scoped directory, per-user cache.
+  const chatDir = join(DOWNLOADS_DIR, slugifyChat(chatName));
+  mkdirSync(chatDir, { recursive: true });
+
+  const results = [];
+  for (let i = 0; i < images.length; i++) {
+    const msg = images[i];
+    const payload = payloads[i];
+    if (!payload || payload.error) {
+      results.push({ imageId: msg.imageId, error: payload?.error ?? "no payload" });
+      continue;
+    }
+    const filename = imageFilename(msg, payload.mimeType);
+    const filepath = join(chatDir, filename);
+    writeFileSync(filepath, Buffer.from(payload.base64, "base64"), { mode: 0o600 });
+    results.push({
+      imageId: msg.imageId,
+      path: filepath,
+      sender: msg.sender,
+      time: msg.time,
+      timestamp: msg.timestamp,
+      mimeType: payload.mimeType,
+    });
+  }
+  return results;
 }
 
 export async function snapshot(page, scope, chatName, localeConfig) {

--- a/lib/e2e-guard.js
+++ b/lib/e2e-guard.js
@@ -48,4 +48,5 @@ export const GUARDED_COMMANDS = Object.freeze([
   "read",
   "send",
   "pollResults",
+  "fetchImages",
 ]);

--- a/lib/e2e.js
+++ b/lib/e2e.js
@@ -94,21 +94,29 @@ async function stageImage(page, localeConfig, sandbox) {
   // Wait for the image to appear in the message panel
   await new Promise((r) => setTimeout(r, 3000));
 
-  // After the sleep/read, call fetchImages to materialize the fixture.
-  let downloads;
+  // fetchImages is NOT on main yet at Plan E time — the image stage asserts
+  // only that the message containing an image is visible. PR #18's rebase
+  // commit extends this stage to call commands.fetchImages and assert the
+  // downloaded path.
+  let messages;
   try {
-    downloads = await commands.fetchImages(page, sandbox, { localeConfig, limit: 1 });
+    messages = await commands.read(page, sandbox, { localeConfig });
   } catch (err) {
-    return { stage: "image", pass: false, duration_ms: now() - start, error: `fetchImages failed: ${err.message}` };
+    return { stage: "image", pass: false, duration_ms: now() - start, error: `read after attach failed: ${err.message}` };
   }
-  const pass = downloads.length >= 1 && downloads[0].path && !downloads[0].error;
+  // Fallback marker: after sendFixtureImage, the most recent message from
+  // sender "You" should be within the last 3 rows. We can't identify image
+  // kind here (PR #18 adds that), so we assert a new "You" message exists
+  // that wasn't there before the stage started. Cheap proxy.
+  const lastYouRows = messages.slice(-5).filter((m) => m.sender === "You");
+  const pass = lastYouRows.length >= 1;
   return {
     stage: "image",
     pass,
     duration_ms: now() - start,
-    imagePath: downloads[0]?.path,  // agent can Read() this for multimodal verify
-    mimeType: downloads[0]?.mimeType,
-    error: pass ? undefined : (downloads[0]?.error ?? "no image downloaded"),
+    messagesInspected: messages.length,
+    note: "image-kind assertion deferred to PR #18 rebase (fetchImages not on main yet)",
+    error: pass ? undefined : "no new 'You' message after attach",
   };
 }
 
@@ -198,21 +206,28 @@ export async function runE2E({ page, localeConfig }) {
   stages.push(text);
   if (!text.pass) return { pass: false, exitCode: 1, stages };
 
-  // Image stage is now active: uses fetchImages (PR #18) to materialize the
-  // uploaded fixture and confirm a file was written.
-  const image = await stageImage(page, localeConfig, sandbox);
-  stages.push(image);
-  if (!image.pass) return { pass: false, exitCode: 1, stages };
-
-  // Link stage remains skipped until PR #17 rebase lands (links[] parser).
+  // Image and link stages are implemented but disabled until PR #16
+  // (navigateToChat robustness) lands on main. Calling navigateToChat
+  // again with a chat already open currently picks up the message-panel
+  // grid instead of the chat list, falling back to a broken search path.
+  // The rebase commit for PR #18 (image download) and PR #17 (links[])
+  // will flip these skipped stages to active.
+  stages.push({
+    stage: "image",
+    pass: true,
+    skipped: true,
+    reason: "disabled until PR #16 (navigateToChat robustness) merges; re-enabled by PR #18 rebase",
+  });
   stages.push({
     stage: "link",
     pass: true,
     skipped: true,
-    reason: "disabled until PR #17 (links[] parser) rebase lands",
+    reason: "disabled until PR #16 (navigateToChat robustness) merges; re-enabled by PR #17 rebase",
   });
-  // Silence unused-symbol lint for stageLink until its rebase.
-  void stageLink;
+  // Silence unused-symbol lints for the implementations we're preserving
+  // for the rebase. (Intentional; tagged with suppression instead of
+  // deleting the functions.)
+  void stageImage; void stageLink;
 
   writeLastRun();
   return { pass: true, exitCode: 0, stages };

--- a/lib/e2e.js
+++ b/lib/e2e.js
@@ -94,29 +94,21 @@ async function stageImage(page, localeConfig, sandbox) {
   // Wait for the image to appear in the message panel
   await new Promise((r) => setTimeout(r, 3000));
 
-  // fetchImages is NOT on main yet at Plan E time — the image stage asserts
-  // only that the message containing an image is visible. PR #18's rebase
-  // commit extends this stage to call commands.fetchImages and assert the
-  // downloaded path.
-  let messages;
+  // After the sleep/read, call fetchImages to materialize the fixture.
+  let downloads;
   try {
-    messages = await commands.read(page, sandbox, { localeConfig });
+    downloads = await commands.fetchImages(page, sandbox, { localeConfig, limit: 1 });
   } catch (err) {
-    return { stage: "image", pass: false, duration_ms: now() - start, error: `read after attach failed: ${err.message}` };
+    return { stage: "image", pass: false, duration_ms: now() - start, error: `fetchImages failed: ${err.message}` };
   }
-  // Fallback marker: after sendFixtureImage, the most recent message from
-  // sender "You" should be within the last 3 rows. We can't identify image
-  // kind here (PR #18 adds that), so we assert a new "You" message exists
-  // that wasn't there before the stage started. Cheap proxy.
-  const lastYouRows = messages.slice(-5).filter((m) => m.sender === "You");
-  const pass = lastYouRows.length >= 1;
+  const pass = downloads.length >= 1 && downloads[0].path && !downloads[0].error;
   return {
     stage: "image",
     pass,
     duration_ms: now() - start,
-    messagesInspected: messages.length,
-    note: "image-kind assertion deferred to PR #18 rebase (fetchImages not on main yet)",
-    error: pass ? undefined : "no new 'You' message after attach",
+    imagePath: downloads[0]?.path,  // agent can Read() this for multimodal verify
+    mimeType: downloads[0]?.mimeType,
+    error: pass ? undefined : (downloads[0]?.error ?? "no image downloaded"),
   };
 }
 
@@ -206,28 +198,21 @@ export async function runE2E({ page, localeConfig }) {
   stages.push(text);
   if (!text.pass) return { pass: false, exitCode: 1, stages };
 
-  // Image and link stages are implemented but disabled until PR #16
-  // (navigateToChat robustness) lands on main. Calling navigateToChat
-  // again with a chat already open currently picks up the message-panel
-  // grid instead of the chat list, falling back to a broken search path.
-  // The rebase commit for PR #18 (image download) and PR #17 (links[])
-  // will flip these skipped stages to active.
-  stages.push({
-    stage: "image",
-    pass: true,
-    skipped: true,
-    reason: "disabled until PR #16 (navigateToChat robustness) merges; re-enabled by PR #18 rebase",
-  });
+  // Image stage is now active: uses fetchImages (PR #18) to materialize the
+  // uploaded fixture and confirm a file was written.
+  const image = await stageImage(page, localeConfig, sandbox);
+  stages.push(image);
+  if (!image.pass) return { pass: false, exitCode: 1, stages };
+
+  // Link stage remains skipped until PR #17 rebase lands (links[] parser).
   stages.push({
     stage: "link",
     pass: true,
     skipped: true,
-    reason: "disabled until PR #16 (navigateToChat robustness) merges; re-enabled by PR #17 rebase",
+    reason: "disabled until PR #17 (links[] parser) rebase lands",
   });
-  // Silence unused-symbol lints for the implementations we're preserving
-  // for the rebase. (Intentional; tagged with suppression instead of
-  // deleting the functions.)
-  void stageImage; void stageLink;
+  // Silence unused-symbol lint for stageLink until its rebase.
+  void stageLink;
 
   writeLastRun();
   return { pass: true, exitCode: 0, stages };

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -239,6 +239,66 @@ function formatTimestamp(date, time) {
 }
 
 /**
+ * Non-cryptographic 32-bit string hash (FNV-like with imul).
+ * Used for stable, compact image IDs derived from message-row identity.
+ * Returns a zero-padded 8-char lowercase hex string.
+ * @param {string} str
+ * @returns {string}
+ */
+export function simpleHash(str) {
+  let h = 0;
+  for (let i = 0; i < str.length; i++) {
+    h = (Math.imul(31, h) + str.charCodeAt(i)) | 0;
+  }
+  return (h >>> 0).toString(16).padStart(8, "0");
+}
+
+/**
+ * Detect whether a message row body contains at least one image attachment.
+ *
+ * Structural, locale-independent heuristic: image messages in WhatsApp Web
+ * aria snapshots appear as a `button "<locale-specific label>":` block whose
+ * immediate children are two or more `- img` lines. This distinguishes them
+ * from emoji reaction buttons (which wrap a single img) and from delivery
+ * status icons (which are bare `img "msg-check"`/`msg-dblcheck` lines, not
+ * inside a button).
+ *
+ * @param {string} rowBody - Indented row body text (children of the row).
+ * @returns {number} Number of image buttons detected (0 = not an image row).
+ */
+function countImageButtons(rowBody) {
+  // Split body into top-level child blocks. A "block" is a `- <whatever>` line
+  // at 4-space indent (direct row children) followed by deeper-indented lines.
+  const lines = rowBody.split("\n");
+  let count = 0;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    // Row children are at 4-space indent in the snapshot (row is at 2-space).
+    const btnMatch = line.match(/^    - button "[^"]*":\s*$/);
+    if (!btnMatch) continue;
+
+    // Collect this button's children (at 6+ space indent until we dedent back).
+    const children = [];
+    for (let j = i + 1; j < lines.length; j++) {
+      const child = lines[j];
+      if (/^      \S/.test(child)) {
+        children.push(child.trim());
+      } else if (/^    \S/.test(child) || /^  \S/.test(child) || child === "") {
+        break;
+      }
+    }
+
+    // Image buttons have children that are exclusively `img` entries (with or
+    // without alt), and at least two of them. Reaction buttons wrap exactly
+    // one img (the reaction emoji); they must NOT match.
+    if (children.length < 2) continue;
+    const allImg = children.every((c) => /^- img(\s|$|")/.test(c));
+    if (allImg) count++;
+  }
+  return count;
+}
+
+/**
  * Parse messages from a WhatsApp Web aria snapshot.
  * Uses structural selectors — message rows are rows NOT inside a grid.
  * Own messages detected via delivery status icons (msg-dblcheck / msg-check).
@@ -419,9 +479,35 @@ export function parseMessages(ariaText, options = {}) {
       }
     }
 
+    // Detect image attachments in this row (structural, locale-independent).
+    // A row may contain BOTH images and text caption — emit one "image" entry
+    // per image button, then fall through to emit the text (if any) as a
+    // separate "text" message so captions remain searchable.
+    const imageButtonCount = countImageButtons(rowBody);
+    if (imageButtonCount > 0) {
+      const timestamp = formatTimestamp(currentDate, time);
+      for (let k = 0; k < imageButtonCount; k++) {
+        // imageId derives from the row's structural identity (sender+time+
+        // rowLabel+index-within-row). Stable across repeated parses of the
+        // same snapshot; changes when the row moves or content updates.
+        const imageId = simpleHash(`${sender}|${time}|${rowLabel}|${k}`);
+        messages.push({
+          kind: "image",
+          sender,
+          text: "",
+          time,
+          timestamp,
+          imageId,
+        });
+      }
+      // If the row also has caption text, fall through and emit it as a text
+      // message below. Otherwise skip to the next row.
+      if (!text) continue;
+    }
+
     if (!text && !time) continue;
 
-    messages.push({ sender, text, time, timestamp: formatTimestamp(currentDate, time) });
+    messages.push({ kind: "text", sender, text, time, timestamp: formatTimestamp(currentDate, time) });
   }
 
   return messages;

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -385,6 +385,46 @@ describe("CLI arg parsing: --index for read", () => {
   });
 });
 
+describe("CLI arg parsing: fetch-images", () => {
+  it("exits 1 with usage when no chat name given", async () => {
+    const { code, stderr } = await runCli("fetch-images");
+    assert.equal(code, 1);
+    assert.ok(
+      stderr.includes("Usage: greentap fetch-images"),
+      `stderr should contain usage, got: ${stderr}`
+    );
+  });
+
+  it("extracts chat name + --limit + --index correctly", () => {
+    // Mirror the arg-parsing pattern already used for the other commands
+    const args = ["fetch-images", "Famiglia Rossi", "--limit", "3", "--index", "2", "--json"];
+    const limitIdx = args.indexOf("--limit");
+    const indexIdx = args.indexOf("--index");
+    const limit = limitIdx >= 0 ? parseInt(args[limitIdx + 1], 10) : undefined;
+    const index = indexIdx >= 0 ? parseInt(args[indexIdx + 1], 10) : undefined;
+    const chat = args.slice(1).filter((a, relI) => {
+      const absI = relI + 1;
+      if (a === "--json" || a === "--limit" || a === "--index") return false;
+      if (limitIdx >= 0 && absI === limitIdx + 1) return false;
+      if (indexIdx >= 0 && absI === indexIdx + 1) return false;
+      return true;
+    })[0];
+    assert.equal(chat, "Famiglia Rossi");
+    assert.equal(limit, 3);
+    assert.equal(index, 2);
+  });
+
+  it("leaves limit and index undefined when flags omitted", () => {
+    const args = ["fetch-images", "Famiglia Rossi"];
+    const limitIdx = args.indexOf("--limit");
+    const indexIdx = args.indexOf("--index");
+    const limit = limitIdx >= 0 ? parseInt(args[limitIdx + 1], 10) : undefined;
+    const index = indexIdx >= 0 ? parseInt(args[indexIdx + 1], 10) : undefined;
+    assert.equal(limit, undefined);
+    assert.equal(index, undefined);
+  });
+});
+
 describe("CLI arg parsing: --index for send", () => {
   it("extracts --index N from send args correctly", () => {
     // Simulate the arg parsing logic from greentap.js for the 'send' command

--- a/test/fetch-images.test.js
+++ b/test/fetch-images.test.js
@@ -1,0 +1,58 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { slugifyChat, imageFilename } from "../lib/commands.js";
+
+describe("slugifyChat", () => {
+  it("lowercases and replaces spaces with hyphens", () => {
+    assert.equal(slugifyChat("Famiglia Rossi"), "famiglia-rossi");
+  });
+
+  it("replaces non-alphanumeric runs with a single hyphen", () => {
+    assert.equal(slugifyChat("Work / Team"), "work-team");
+  });
+
+  it("trims leading/trailing whitespace and hyphens", () => {
+    assert.equal(slugifyChat("  Spaces  "), "spaces");
+    assert.equal(slugifyChat("--dashes--"), "dashes");
+  });
+
+  it("collapses runs of special characters", () => {
+    assert.equal(slugifyChat("A!!!B???C"), "a-b-c");
+  });
+
+  it("drops emoji and produces a safe ASCII slug", () => {
+    const slug = slugifyChat("Famiglia Rossi 🎉");
+    assert.ok(/^[a-z0-9-]+$/.test(slug), `slug should be ascii-safe, got: ${slug}`);
+    assert.ok(slug.includes("famiglia-rossi"));
+  });
+
+  it("returns empty string for all-special input", () => {
+    assert.equal(slugifyChat("///"), "");
+  });
+});
+
+describe("imageFilename", () => {
+  it("uses the imageId with jpg for image/jpeg", () => {
+    assert.equal(imageFilename({ imageId: "abc12345" }, "image/jpeg"), "abc12345.jpg");
+  });
+
+  it("uses the imageId with png for image/png", () => {
+    assert.equal(imageFilename({ imageId: "abc12345" }, "image/png"), "abc12345.png");
+  });
+
+  it("uses webp extension for image/webp", () => {
+    assert.equal(imageFilename({ imageId: "abc12345" }, "image/webp"), "abc12345.webp");
+  });
+
+  it("uses gif extension for image/gif", () => {
+    assert.equal(imageFilename({ imageId: "abc12345" }, "image/gif"), "abc12345.gif");
+  });
+
+  it("falls back to .bin for unknown mime types", () => {
+    assert.equal(imageFilename({ imageId: "abc12345" }, "application/octet-stream"), "abc12345.bin");
+  });
+
+  it("falls back to .bin when mime is undefined", () => {
+    assert.equal(imageFilename({ imageId: "abc12345" }, undefined), "abc12345.bin");
+  });
+});

--- a/test/fixtures/image-messages.snapshot.txt
+++ b/test/fixtures/image-messages.snapshot.txt
@@ -1,0 +1,51 @@
+- document:
+  - banner:
+    - button "Dettagli profilo":
+      - img
+    - button "Famiglia Rossi clicca qui per info gruppo"
+    - button "Videochiamata di gruppo": Chiama
+    - button "Cerca"
+    - button "Menu"
+  - text: Oggi
+  - button "Apri dettagli chat di Roberto Marini":
+    - img
+  - row "Roberto Marini Ciao a tutti! 09:15":
+    - text: Roberto Marini Ciao a tutti! 09:15
+  - button "Apri dettagli chat di Elena Conti":
+    - img
+  - row "Elena Conti Apri immagine 09:20":
+    - text: Elena Conti
+    - button "Apri immagine":
+      - img
+      - img
+    - text: "09:20"
+  - button "Apri dettagli chat di Roberto Marini":
+    - img
+  - row "Roberto Marini Apri immagine Apri immagine Bella! 10:00":
+    - text: Roberto Marini
+    - button "Apri immagine":
+      - img "Foto di gruppo"
+      - img "Foto di gruppo"
+      - img "Foto di gruppo"
+    - button "Apri immagine":
+      - img
+      - img
+      - img
+    - text: Bella!
+    - text: "10:00"
+  - row "Grazie! 10:05 Letto":
+    - text: Grazie! 10:05
+    - img "msg-dblcheck"
+  - row "Ecco la mia 10:06 Letto":
+    - text: Ecco la mia 10:06
+    - button "Apri immagine":
+      - img
+      - img
+    - img "msg-dblcheck"
+  - contentinfo:
+    - button "Allega"
+    - button "Emoji, GIF, Sticker"
+    - textbox "Scrivi al gruppo Famiglia Rossi":
+      - paragraph
+    - button "Messaggio vocale":
+      - button "Messaggio vocale"

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -405,6 +405,87 @@ describe("parseSearchResults", () => {
   });
 });
 
+describe("parseMessages — image detection", () => {
+  const ITALIAN_TEST_LOCALE = {
+    dayNames: ["lunedì", "martedì", "mercoledì", "giovedì", "venerdì", "sabato", "domenica"],
+    yesterday: "Ieri",
+    today: "Oggi",
+    dateRegex: "\\d{2}\\/\\d{2}\\/\\d{4}",
+  };
+
+  it("flags image messages with kind='image'", () => {
+    const aria = loadFixture("image-messages.snapshot.txt");
+    const messages = parseMessages(aria, { localeConfig: ITALIAN_TEST_LOCALE });
+    const images = messages.filter((m) => m.kind === "image");
+    assert.ok(images.length >= 1, `expected at least one image message, got messages: ${JSON.stringify(messages, null, 2)}`);
+  });
+
+  it("image messages have required fields (imageId, sender, time, kind)", () => {
+    const aria = loadFixture("image-messages.snapshot.txt");
+    const messages = parseMessages(aria, { localeConfig: ITALIAN_TEST_LOCALE });
+    const images = messages.filter((m) => m.kind === "image");
+    for (const img of images) {
+      assert.equal(typeof img.imageId, "string", "imageId should be string");
+      assert.ok(img.imageId.length > 0, "imageId should be non-empty");
+      assert.equal(typeof img.sender, "string", "sender should be string");
+      assert.equal(typeof img.time, "string", "time should be string");
+      assert.equal(img.kind, "image");
+    }
+  });
+
+  it("imageIds are stable across repeated parses (same fixture → same ids)", () => {
+    const aria = loadFixture("image-messages.snapshot.txt");
+    const first = parseMessages(aria, { localeConfig: ITALIAN_TEST_LOCALE }).filter((m) => m.kind === "image");
+    const second = parseMessages(aria, { localeConfig: ITALIAN_TEST_LOCALE }).filter((m) => m.kind === "image");
+    assert.equal(first.length, second.length);
+    for (let i = 0; i < first.length; i++) {
+      assert.equal(first[i].imageId, second[i].imageId, `image ${i} imageId should match across parses`);
+    }
+  });
+
+  it("imageIds are unique within a snapshot", () => {
+    const aria = loadFixture("image-messages.snapshot.txt");
+    const messages = parseMessages(aria, { localeConfig: ITALIAN_TEST_LOCALE });
+    const images = messages.filter((m) => m.kind === "image");
+    const ids = images.map((m) => m.imageId);
+    const unique = new Set(ids);
+    assert.equal(unique.size, ids.length, `expected unique imageIds, got: ${ids.join(", ")}`);
+  });
+
+  it("attributes own image messages to 'You' via msg-dblcheck", () => {
+    const aria = loadFixture("image-messages.snapshot.txt");
+    const messages = parseMessages(aria, { localeConfig: ITALIAN_TEST_LOCALE });
+    const own = messages.filter((m) => m.kind === "image" && m.sender === "You");
+    assert.ok(own.length >= 1, `expected at least one own image message, got: ${JSON.stringify(messages.filter((m) => m.kind === "image"), null, 2)}`);
+  });
+
+  it("attributes other-sender image messages to the sender name", () => {
+    const aria = loadFixture("image-messages.snapshot.txt");
+    const messages = parseMessages(aria, { localeConfig: ITALIAN_TEST_LOCALE });
+    const images = messages.filter((m) => m.kind === "image");
+    const fromOther = images.filter((m) => m.sender && m.sender !== "You");
+    assert.ok(fromOther.length >= 1, "expected at least one image from another sender");
+    // Our fixture has Elena Conti + Roberto Marini
+    const senders = new Set(fromOther.map((m) => m.sender));
+    assert.ok(senders.has("Elena Conti") || senders.has("Roberto Marini"), `expected a fake persona sender, got: ${[...senders].join(", ")}`);
+  });
+
+  it("non-image messages keep kind='text'", () => {
+    const aria = loadFixture("image-messages.snapshot.txt");
+    const messages = parseMessages(aria, { localeConfig: ITALIAN_TEST_LOCALE });
+    const texts = messages.filter((m) => m.kind === "text");
+    assert.ok(texts.length >= 1, "expected at least one text message");
+  });
+
+  it("detects image messages in the real chat-aria fixture", () => {
+    // Regression: chat-aria.txt contains 3 real image rows (Roberto x2, Sara x2) with fake personas
+    const aria = loadFixture("chat-aria.txt");
+    const messages = parseMessages(aria);
+    const images = messages.filter((m) => m.kind === "image");
+    assert.ok(images.length >= 1, `expected at least one image in chat-aria.txt, got ${images.length}`);
+  });
+});
+
 describe("parsePollMessages", () => {
   it("parses poll from fixture", () => {
     const aria = loadFixture("poll-aria.txt");


### PR DESCRIPTION
## Summary

Lets agents *see* images sent in WhatsApp chats.

- `read --json` now marks image messages with `kind: "image"` and a stable `imageId` (no inline payload).
- New `greentap fetch-images <chat> [--limit N] [--json]` downloads currently-visible images via in-DOM `fetch(blobUrl)` to `~/.greentap/downloads/<chat-slug>/<imageId>.<ext>`.
- Agents then `Read` each path — Claude's multimodal pipeline handles content understanding.

Plan: [`docs/superpowers/plans/2026-04-22-image-download.md`](docs/superpowers/plans/2026-04-22-image-download.md)

## Commits (4)

1. `docs: add image download implementation plan`
2. `feat(parser): detect image messages with kind='image'+imageId`
3. `feat(commands): add fetchImages — in-DOM blob to ~/.greentap/downloads`
4. `feat(cli): add fetch-images subcommand`

## Tests

`npm test`: 107 passing, 0 failing (+15 new: 7 parser image tests, helper tests, 3 CLI arg tests).

## Review findings

- `/review-code`: no blockers. 7 advisories — most notable: `fetchImages` main flow is not unit-tested (helpers only); smoke test deferred to live run.
- `/review-security`: no blockers. 9 advisories. Path-traversal neutralized by `slugifyChat` (strict `[a-z0-9]+` allowlist). File mode `0o600`, no new fingerprint, no content logged.

## Plan deviations worth a glance

1. **Task 1 done differently.** Plan assumed images appear as `img "Photo"` in ARIA — in reality WhatsApp Web renders them as `button "<locale label>"` wrapping 2+ `img` children. Detection switched to a structural pattern (locale-independent, ignores button label). Fixture was hand-crafted with fake personas (PII-free). The existing `chat-aria.txt` fixture already contained 3 real-world image rows; a regression test asserts they're now detected.
2. **Task 5 (SKILL.md block) skipped — harness permission denied.** Three edit attempts on `.claude/skills/greentap/SKILL.md` returned permission errors. New command is documented in `README.md` and `CLAUDE.md`, not yet in SKILL.md — please apply the "Reading images from a chat" block (plan lines 469-503) manually.

## Manual steps required before release

1. Apply SKILL.md block manually (plan lines 469-503).
2. Manual smoke test: `greentap fetch-images "<test chat>" --limit 3 --json`, then Read each returned path.
3. `test/fixtures/image-messages.snapshot.txt` is hand-crafted. A real aria snapshot may have additional children inside image buttons (e.g. a "play" overlay for GIFs) that the heuristic doesn't anticipate. Consider replacing with a live capture from a test chat of public-domain images.

## Test plan

- [ ] Send 3 images to a test chat (fake personas, public-domain content)
- [ ] `greentap fetch-images "<test chat>" --limit 3 --json`
- [ ] `file ~/.greentap/downloads/<slug>/*.jpg` — confirm JPEG/PNG/WebP
- [ ] Read each path in Claude → confirm multimodal understanding works
- [ ] Apply SKILL.md block