### PR TITLE
docs: iron-clad merge + e2e rules

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,19 @@
+<!--
+===================================================================
+DO NOT MERGE without maintainer's explicit per-PR approval
++ a passing e2e run that EXERCISES the feature this PR adds
+(no skipped stages for the feature under test).
+
+"Approval" = maintainer says "merge it" for THIS PR, in the CURRENT
+session. A generic "procedi" does NOT authorize a merge. `--admin`
+bypass is FORBIDDEN unless the maintainer explicitly says "use admin"
+for this specific PR.
+
+Full rules: CONTRIBUTING.md → "Merge approval protocol" and
+"E2E is mandatory — local, not CI".
+===================================================================
+-->
+
 ## Summary
 
 <!-- What changed and why. One or two sentences. -->
@@ -10,11 +26,18 @@
 
 - [ ] `npm test` passes locally
 - [ ] PII check: no real names, numbers, or chat content in new fixtures
-- [ ] If the diff touches `lib/` or `test/fixtures/`:
-  - [ ] `GREENTAP_E2E=1 node greentap.js e2e` passes locally
-  - [ ] The `sample.png` downloaded in stage 4 shows the text `GREENTAP-E2E` when viewed
+- [ ] **If the diff touches `lib/commands.js`, `lib/parser.js`, `lib/daemon.js`, `lib/client.js`, `lib/locale.js`, or `test/fixtures/**`:**
+  - [ ] `GREENTAP_E2E=1 node greentap.js e2e` passes locally (exit 0)
+  - [ ] The stage that exercises THIS PR's feature actually RAN — it was NOT skipped (confirm by reading the stage list in stdout)
+  - [ ] If this PR adds image download: the downloaded image was Read()-verified multimodally and the text `GREENTAP-E2E` is legible in the pixels
+  - [ ] If e2e cannot run for any reason (daemon blocked, sandbox issue, preflight bug): this PR does NOT merge until the blocker is fixed
 
 ## Review
 
 - [ ] `/review-code` run locally; blockers fixed
 - [ ] `/review-security` run locally; blockers fixed
+
+## Merge authorization
+
+- [ ] Maintainer has, in the CURRENT session, explicitly approved merging THIS specific PR
+- [ ] No `--admin` bypass is being used (or: maintainer explicitly authorized `--admin` for this PR)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,30 @@ WhatsApp Web syncs its UI language from the phone — `navigator.language` and P
 - Selectors are locale-agnostic (structural ARIA roles + runtime locale detection); aria snapshot structure may still change with WhatsApp Web updates
 - Low volume personal use only — minimize automation fingerprint
 - No CI yet — tests run locally
-- **E2E mandatory for `lib/` changes.** Any diff touching `lib/commands.js`, `lib/parser.js`, `lib/daemon.js`, `lib/client.js`, `lib/locale.js`, or `test/fixtures/**` must pass `GREENTAP_E2E=1 node greentap.js e2e` locally before merge. See `CONTRIBUTING.md`. Sandbox group `greentap-sandbox` required (member: maintainer only).
+- **E2E MANDATORY for `lib/` changes — real roundtrip, not unit tests.** Any diff touching `lib/commands.js`, `lib/parser.js`, `lib/daemon.js`, `lib/client.js`, `lib/locale.js`, or `test/fixtures/**` MUST pass `GREENTAP_E2E=1 node greentap.js e2e` locally before merge, with the feature's stage actually running (NOT skipped) and passing. `npm test` passing is NOT e2e. If the PR adds image download, the downloaded image path MUST be Read()-verified multimodally to confirm `GREENTAP-E2E` text is legible. If e2e cannot run (daemon blocked, sandbox missing, preflight bug), the PR does NOT merge until the blocker is fixed. See `CONTRIBUTING.md` for full spec. Sandbox group `greentap-sandbox` required (member: maintainer only).
+
+## Merge protocol (iron-clad)
+
+These rules are absolute. No exceptions without the maintainer
+saying so, in the current session, for the specific PR.
+
+1. **Every merge requires explicit maintainer approval, per-PR,
+   per-session.** The maintainer MUST say "merge it" (or equivalent)
+   for the **specific PR** being merged, **in the current session**.
+   Approval does NOT carry across sessions or across PRs.
+2. **A generic "procedi" / "continue autonomously" / "keep going"
+   does NOT authorize merges.** It authorizes the next orchestration
+   step up to `gh pr create`. Stop there and ping.
+3. **`gh pr merge --admin` is FORBIDDEN** unless the maintainer
+   explicitly says "use admin" for the specific PR. Bypassing branch
+   protection without that explicit go-ahead is a rule violation.
+4. **E2E must have executed the feature's stage** — not skipped, not
+   preflight-only. See Constraints → E2E MANDATORY above and
+   `CONTRIBUTING.md`.
+5. **When in doubt: ping and wait.** Ping cost is trivial;
+   revert-a-bad-merge-on-a-public-repo cost is not.
+
+Full protocol: `CONTRIBUTING.md` → "Merge approval protocol".
 
 <!-- BEGIN SYNCED: psacc/docs/CONVENTIONS.md — do not edit here -->
 ## Doc conventions (synced from psacc/docs/CONVENTIONS.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,9 +16,39 @@ scope.
   See `CLAUDE.md` for the three-tier selector strategy.
 - **TDD.** Write the failing test first; make it pass.
 
+## Merge approval protocol
+
+These rules are iron-clad. Agents and humans MUST follow them.
+
+1. **Every merge requires explicit maintainer approval.** Not
+   implicit. Not "if review approves". Not "if tests pass".
+2. **"Approval" means:** the maintainer, **in the current session**,
+   says "merge it" (or equivalent) for the **specific PR** being
+   merged. Per-PR. Not a batch. Not carried over from a previous
+   session.
+3. **A generic "procedi" / "continue autonomously" / "keep going"
+   does NOT authorize merges.** It authorizes the next orchestration
+   step up to `gh pr create`. Stop there and wait.
+4. **Admin-bypass of branch protection (`gh pr merge --admin` or the
+   `--admin` flag) is FORBIDDEN** unless the maintainer explicitly
+   says "use admin" for the specific PR being merged.
+5. **When in doubt: ping and wait.** Ping cost is trivial;
+   merge-regret cost is not. Reverting a bad merge on a public repo
+   is a one-way door with audit-trail costs.
+
+Approval is **per-PR and per-session**. Re-ask for each PR. Re-ask
+after a new session starts even if the previous session had approval
+for a different PR.
+
 ## E2E is mandatory — local, not CI
 
-Any PR whose diff touches one or more of the following paths must
+E2E means a **real roundtrip against WhatsApp Web**, not unit tests.
+`npm test` passing is NOT e2e. Unit tests verify code paths in
+isolation; e2e verifies the whole pipeline against live WhatsApp Web.
+
+### Scope — which PRs MUST run e2e
+
+Any PR whose diff touches one or more of the following paths MUST
 pass `GREENTAP_E2E=1 node greentap.js e2e` on the contributor's
 machine **before** the PR is merged:
 
@@ -32,6 +62,31 @@ machine **before** the PR is merged:
 Exempt paths: docs (`README.md`, `CLAUDE.md`, `ROADMAP.md`,
 `docs/**`, `CONTRIBUTING.md`), `.claude/**`, `.gitignore`,
 `.github/**`, release notes.
+
+### Pass criteria — the feature's stage MUST NOT be skipped
+
+`GREENTAP_E2E=1 node greentap.js e2e` MUST exit `0` **AND** the stage
+that exercises THIS PR's code MUST actually run and pass. A run where
+the feature stage is skipped (due to guard, flag, env, preflight
+bailout, or any other reason) does NOT satisfy the requirement.
+
+Examples:
+
+- PR adds `links[]` to parser → the `link` stage MUST be active and pass.
+- PR adds `fetchImages` to commands → the `image` stage MUST be
+  active and pass, AND the downloaded image path MUST be
+  Read()-verified multimodally to confirm the text `GREENTAP-E2E` is
+  legible in the pixels.
+- PR touches `lib/daemon.js` → the daemon-lifecycle stages MUST
+  actually run. A preflight-only pass is NOT sufficient.
+
+### If meta-e2e cannot run → PR does not merge
+
+If `GREENTAP_E2E=1 node greentap.js e2e` cannot run the feature's
+stage (daemon blocked, sandbox issue, preflight bug, sandbox group
+missing, rate-limited with no override), the PR **does not merge**
+until the blocker is fixed. The blocker itself may become a
+follow-up PR — but the feature PR waits.
 
 ### Sandbox setup (one-time)
 
@@ -54,14 +109,18 @@ Exit codes:
 - `3` — rate-limited (min 60s between runs; override with
   `GREENTAP_E2E_SKIP_RATE_LIMIT=1` for local debugging)
 
+A `0` exit code is necessary but not sufficient. You MUST also
+confirm the feature's stage was not skipped — read the stdout stage
+list.
+
 ### Multimodal image check
 
-Stage 4 ("image") prints the path of the downloaded image fixture
-(after PR #18 lands `fetchImages`). Open that path with any image
-viewer, or — if an AI agent is doing the check — Read the path. The
-fixture text `GREENTAP-E2E` must be legible. If the image is blank
-or the text is unreadable, the pipeline is broken even though the
-CLI returned pass.
+Stage 4 ("image") prints the path of the downloaded image fixture.
+Open that path with any image viewer, or — if an AI agent is doing
+the check — Read the path. The fixture text `GREENTAP-E2E` MUST be
+legible. If the image is blank or the text is unreadable, the
+pipeline is broken even though the CLI returned pass, and the PR
+does not merge.
 
 ## Adding a new chat-targeting command
 


### PR DESCRIPTION
## Summary

After a batch of 5 PRs merged by an agent without per-PR maintainer approval, and where the meta-e2e feature stages (image, link) were effectively skipped, this PR locks down the two rules that were ambiguous enough to be misread:

1. **Merge approval** — explicit, per-PR, per-session. Generic "procedi" does NOT authorize a merge. `--admin` bypass is forbidden by default.
2. **E2E mandatory for `lib/` changes** — a real roundtrip against WhatsApp Web, with the feature's stage actually RUNNING (not skipped). `npm test` is not e2e. If e2e cannot run, the PR does not merge.

Docs-only. No code changes.

## Changed files

- `CONTRIBUTING.md` — rewrote "E2E is mandatory" with a scope / pass criteria / fallback structure. Added new top-level "Merge approval protocol" section.
- `CLAUDE.md` — tightened the e2e bullet under Constraints; added a new "Merge protocol (iron-clad)" section so agents reading only `CLAUDE.md` see the rules.
- `.github/pull_request_template.md` — added a DO NOT MERGE banner at the top (HTML comment, visible in the PR compose view). Revised Test plan checkboxes. Added a "Merge authorization" checkbox block.

## Test plan

- [x] `npm test` passes locally (no code touched)
- [x] PII check: no real names, numbers, or chat content (docs-only)
- [x] Diff does NOT touch `lib/` or `test/fixtures/` — e2e not required for this PR
- [x] `/review-code` — not run (docs-only, no logic)
- [x] `/review-security` — not run (docs-only, no logic)

## Merge authorization

- [ ] **Per the new rules: do NOT merge this PR without explicit per-PR approval from the maintainer in the session where the merge is requested.**