### PR TITLE
fix(daemon): strip HeadlessChrome UA for WhatsApp Web

### DIFF
--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -118,10 +118,16 @@ async function main() {
         userAgent: currentUA.replace("HeadlessChrome", "Chrome"),
       });
     }
-  } catch {
+  } catch (err) {
     // If CDP override fails, WA may still reject headless; the chat-list
     // waitFor below will timeout and the daemon stays up so the client
-    // can surface the issue. Don't fatally exit here.
+    // can surface the issue. Log the failure so it's diagnosable — without
+    // this, the symptom is a confusing 30s grid-waitFor timeout 10 lines
+    // below with no hint at the root cause.
+    // (Scope: the override targets only this page's Network domain.
+    // Greentap's single-page model makes that sufficient; a multi-page
+    // refactor would need the override at every new page.)
+    console.error("[daemon] UA override failed:", err?.message);
   }
 
   await page.goto(WA_URL);

--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -105,6 +105,25 @@ async function main() {
 
   // Navigate to WhatsApp Web
   const page = context.pages()[0] || (await context.newPage());
+
+  // Bundled Chromium advertises `HeadlessChrome/...` in its User-Agent.
+  // WhatsApp Web rejects that with "update your browser" and never loads
+  // the chat UI. Strip the `Headless` marker via CDP so the UA looks
+  // like a regular Chrome release. Harmless when already non-headless.
+  try {
+    const uaCdp = await context.newCDPSession(page);
+    const currentUA = await page.evaluate(() => navigator.userAgent);
+    if (currentUA.includes("HeadlessChrome")) {
+      await uaCdp.send("Network.setUserAgentOverride", {
+        userAgent: currentUA.replace("HeadlessChrome", "Chrome"),
+      });
+    }
+  } catch {
+    // If CDP override fails, WA may still reject headless; the chat-list
+    // waitFor below will timeout and the daemon stays up so the client
+    // can surface the issue. Don't fatally exit here.
+  }
+
   await page.goto(WA_URL);
 
   // Wait for chat list (may take a while on first load)


### PR DESCRIPTION
## Summary

After #15 switched the daemon to Playwright's bundled Chromium, WhatsApp Web
rejects the headless UA with an "update your browser" banner and never loads
the chat list. This patch overrides the UA via CDP
`Network.setUserAgentOverride`, replacing `HeadlessChrome` with `Chrome`
right after the persistent context launches.

## Bug source

Discovered by the real-e2e validation subagent. Previous cold-start ran into:
- `chatGrid.waitFor({timeout: 30000})` timing out because the WA page is blocked by the "update your browser" gate.
- Any `greentap login` post-#15 would fail to complete.

## Meta-e2e (local, real sandbox)

Cold-started daemon with bundled Chromium + the UA fix, then:

```
$ time node greentap.js chats --json | head -c 200
[{"name":"<real chat>","time":"12:27","..."},
 {"name":"greentap-sandbox","time":"11:41","..."}, ...]
node greentap.js chats --json  0.25s user ...
```

28 chats returned, `greentap-sandbox` present. Chat-list load completed, no "update your browser" gate.

## Tests

`npm test`: 132/132 pass (no changes to test suite — existing tests don't
cover daemon bootstrap).

## Blocks

This PR unblocks:
- R3 (link merge brittleness fix)
- R2 (fetchImages DOM selector rewrite)
- R4 (e2e preflight + image stage)
- Any future `greentap login` or cold-start from a fresh `~/.greentap/browser-data/`

## Test plan

- [x] Cold-started daemon; `chats --json` returns full chat list
- [x] `npm test` green
- [x] No new PII in diff
- [ ] Maintainer independent review