### PR TITLE
fix(navigate): fast-path when target chat is already open

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -67,6 +67,29 @@ export async function waitForMessagePanel(page) {
 
 export async function navigateToChat(page, chatName, localeConfig, index = undefined) {
   assertE2EAllowed(chatName);
+
+  // Fast-path: already in the target chat. When a chat is open, the chat
+  // header exposes a button whose aria label is either the chat name
+  // (direct messages) or the chat name followed by a locale-specific
+  // suffix (e.g. "greentap-sandbox clicca qui per info gruppo" for
+  // groups, in Italian). If that header is present, skip navigation.
+  //
+  // Without this fast-path, callers like `read()`, `send()`, and
+  // `fetchImages()` re-enter navigateToChat after each other and hit a
+  // pre-existing bug: `page.getByRole("grid").first()` picks up the
+  // message-panel grid (not the chat list) when a chat is already open,
+  // falls through to the search fallback, and search types into the
+  // compose textbox instead of the search box. Net effect: "Chat not
+  // found" even though the chat is visible and active.
+  try {
+    const fastAria = await page.locator(":root").ariaSnapshot();
+    const escaped = chatName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const headerRe = new RegExp(`button "${escaped}(?: [^"]*)?"`);
+    if (headerRe.test(fastAria)) return;
+  } catch {
+    // If aria read fails for any reason, fall through to the normal path.
+  }
+
   // Try visible chat list first — parse aria for exact name match.
   // Wait up to 2s for the grid to render before falling back to search.
   // Without this wait, a freshly-opened daemon or post-reload state may see

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -81,13 +81,25 @@ export async function navigateToChat(page, chatName, localeConfig, index = undef
   // falls through to the search fallback, and search types into the
   // compose textbox instead of the search box. Net effect: "Chat not
   // found" even though the chat is visible and active.
+  //
+  // IMPORTANT: scope the aria read to the LAST `role="banner"` on the
+  // page. A full-page aria scan false-positives on poll authors,
+  // forwarded-message authors, and reply-quote labels — all render as
+  // `button "<name>"` inside the message panel. WA Web's layout puts
+  // the sidebar banners (tabs, app header) first and the chat header
+  // banner last, so `.last()` is the chat header.
   try {
-    const fastAria = await page.locator(":root").ariaSnapshot();
+    const headerAria = await page
+      .getByRole("banner")
+      .last()
+      .ariaSnapshot({ timeout: 500 });
     const escaped = chatName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
     const headerRe = new RegExp(`button "${escaped}(?: [^"]*)?"`);
-    if (headerRe.test(fastAria)) return;
+    if (headerRe.test(headerAria)) return;
   } catch {
-    // If aria read fails for any reason, fall through to the normal path.
+    // If aria read fails (no banner, timeout, Playwright error), fall
+    // through to the normal grid-or-search path. Graceful degradation —
+    // correctness is preserved, only the fast-path optimization is lost.
   }
 
   // Try visible chat list first — parse aria for exact name match.

--- a/test/navigate.test.js
+++ b/test/navigate.test.js
@@ -23,6 +23,7 @@ function makeFakePage({
   gridAria = "",
   searchAria = "",
   searchThrows = false,
+  headerAria = "",
 } = {}) {
   const started = Date.now();
   const gridIsVisible = () => Date.now() - started >= gridVisibleAfterMs;
@@ -77,6 +78,15 @@ function makeFakePage({
     getByRole: () => composeTextbox,
   };
 
+  // The chat header banner (last banner on the page). Fast-path scopes
+  // its aria read here to avoid false-positives from message-panel
+  // content (poll author buttons, forwarded-message labels, etc.).
+  const bannerLocator = {
+    first: () => bannerLocator,
+    last: () => bannerLocator,
+    ariaSnapshot: async () => headerAria,
+  };
+
   const page = {
     getByRole: (role) => {
       if (role === "grid") {
@@ -87,6 +97,9 @@ function makeFakePage({
       }
       if (role === "textbox") {
         return { first: () => searchTextbox };
+      }
+      if (role === "banner") {
+        return bannerLocator;
       }
       if (role === "gridcell") {
         return {};
@@ -144,10 +157,10 @@ const ROBERTO_GRID = `- grid "Lista delle chat":
 `;
 
 describe("navigateToChat: fast-path when chat is already open", () => {
-  it("returns immediately when full-page aria exposes the chat header button (direct chat)", async () => {
+  it("returns immediately when chat header banner exposes the chat name button (direct chat)", async () => {
     const page = makeFakePage({
       gridVisibleAfterMs: 10_000, // would force search path if reached
-      searchAria: 'button "Roberto Marini"',
+      headerAria: '- banner:\n  - button "Roberto Marini"',
     });
     await commands.navigateToChat(page, "Roberto Marini", null);
     assert.equal(page._calls.gridClick, 0, "grid should NOT be clicked");
@@ -157,18 +170,18 @@ describe("navigateToChat: fast-path when chat is already open", () => {
   it("matches group-style header with locale-specific suffix", async () => {
     const page = makeFakePage({
       gridVisibleAfterMs: 10_000,
-      searchAria: 'button "greentap-sandbox clicca qui per info gruppo"',
+      headerAria: '- banner:\n  - button "greentap-sandbox clicca qui per info gruppo"',
     });
     await commands.navigateToChat(page, "greentap-sandbox", null);
     assert.equal(page._calls.gridClick, 0);
     assert.equal(page._calls.searchClick, 0);
   });
 
-  it("falls through to normal navigation when header is not present", async () => {
+  it("falls through to normal navigation when chat header does not match", async () => {
     const page = makeFakePage({
       gridVisibleAfterMs: 0,
       gridAria: ROBERTO_GRID,
-      searchAria: 'button "someone-else"', // does NOT match
+      headerAria: '- banner:\n  - button "someone-else"', // does NOT match
     });
     await commands.navigateToChat(page, "Roberto Marini", null);
     assert.equal(page._calls.gridClick, 1, "grid path should have taken over");
@@ -179,16 +192,40 @@ describe("navigateToChat: fast-path when chat is already open", () => {
     // the fast-path could accidentally trigger on `button "fooXbar"`.
     const page = makeFakePage({
       gridVisibleAfterMs: 10_000,
-      searchAria: 'button "fooXbar"',
+      headerAria: '- banner:\n  - button "fooXbar"',
     });
     await assert.rejects(
       () => commands.navigateToChat(page, "foo.bar", null),
-      // With searchAria not containing the real header, the normal path
-      // is forced. Grid is not visible (10s delay) and search aria has no
-      // row → "Chat not found" from search fallback.
+      // Fast-path does NOT match → normal path runs. Grid not visible,
+      // search aria empty → "Chat not found" from the search fallback.
       (err) => /not found/.test(err.message),
     );
     assert.equal(page._calls.gridClick, 0);
+  });
+
+  it("does NOT false-positive on poll author or forward labels in the message panel", async () => {
+    // Regression guard for the BLOCK finding in /review-code on PR #24.
+    // Previously, the fast-path read the full-page aria and matched any
+    // `button "<name>"` — including poll authors and forward labels
+    // inside the message panel. The fix scopes the read to the chat
+    // header banner only. Here we simulate being in chat "Elena Conti"
+    // with a poll authored by "Roberto Marini" visible in the panel:
+    // navigateToChat(page, "Roberto Marini") must NOT return early,
+    // because the chat header is Elena, not Roberto.
+    const page = makeFakePage({
+      gridVisibleAfterMs: 10_000,
+      // The chat HEADER (scoped locator) shows Elena. Fast-path reads
+      // only this — the poll author is in the message panel, which we
+      // do NOT expose via getByRole("banner").last().
+      headerAria: '- banner:\n  - button "Elena Conti"',
+      searchAria: TWO_FERRAGOSTO_AND_ELENA, // irrelevant — won't be read by fast-path
+    });
+    await assert.rejects(
+      () => commands.navigateToChat(page, "Roberto Marini", null),
+      // Fast-path correctly doesn't fire; normal path runs; grid never
+      // visible + search aria doesn't contain Roberto → "not found".
+      (err) => /not found/.test(err.message),
+    );
   });
 });
 

--- a/test/navigate.test.js
+++ b/test/navigate.test.js
@@ -143,6 +143,55 @@ const ROBERTO_GRID = `- grid "Lista delle chat":
     - textbox "Scrivi un messaggio"
 `;
 
+describe("navigateToChat: fast-path when chat is already open", () => {
+  it("returns immediately when full-page aria exposes the chat header button (direct chat)", async () => {
+    const page = makeFakePage({
+      gridVisibleAfterMs: 10_000, // would force search path if reached
+      searchAria: 'button "Roberto Marini"',
+    });
+    await commands.navigateToChat(page, "Roberto Marini", null);
+    assert.equal(page._calls.gridClick, 0, "grid should NOT be clicked");
+    assert.equal(page._calls.searchClick, 0, "search should NOT be clicked");
+  });
+
+  it("matches group-style header with locale-specific suffix", async () => {
+    const page = makeFakePage({
+      gridVisibleAfterMs: 10_000,
+      searchAria: 'button "greentap-sandbox clicca qui per info gruppo"',
+    });
+    await commands.navigateToChat(page, "greentap-sandbox", null);
+    assert.equal(page._calls.gridClick, 0);
+    assert.equal(page._calls.searchClick, 0);
+  });
+
+  it("falls through to normal navigation when header is not present", async () => {
+    const page = makeFakePage({
+      gridVisibleAfterMs: 0,
+      gridAria: ROBERTO_GRID,
+      searchAria: 'button "someone-else"', // does NOT match
+    });
+    await commands.navigateToChat(page, "Roberto Marini", null);
+    assert.equal(page._calls.gridClick, 1, "grid path should have taken over");
+  });
+
+  it("escapes regex metacharacters in chat name (no header match for foo.bar)", async () => {
+    // If escaping is broken, `.` in "foo.bar" would match any char and
+    // the fast-path could accidentally trigger on `button "fooXbar"`.
+    const page = makeFakePage({
+      gridVisibleAfterMs: 10_000,
+      searchAria: 'button "fooXbar"',
+    });
+    await assert.rejects(
+      () => commands.navigateToChat(page, "foo.bar", null),
+      // With searchAria not containing the real header, the normal path
+      // is forced. Grid is not visible (10s delay) and search aria has no
+      // row → "Chat not found" from search fallback.
+      (err) => /not found/.test(err.message),
+    );
+    assert.equal(page._calls.gridClick, 0);
+  });
+});
+
 describe("navigateToChat: grid determinism (waitFor gate)", () => {
   it("uses grid path when grid becomes visible within the wait window", async () => {
     const page = makeFakePage({


### PR DESCRIPTION
## Summary

`navigateToChat` was always going through its grid-or-search decision, even when the caller was already in the target chat. When a chat is open, `page.getByRole('grid').first()` picks up the message-panel grid instead of the chat-list sidebar, `parseChatList` finds nothing, the search fallback runs, and `page.getByRole('textbox').first()` resolves to the compose textbox — the search query gets typed into the draft.

Result: every re-entry (`read()` after `send()`, `fetchImages()` after `send()`, any two greentap commands back-to-back on the same chat) crashed with `"Chat not found"`.

This is the "pre-existing bug" called out by the PR #16 reviewer. It blocked #17, #18, and the e2e harness image/link stages from ever working end-to-end.

## The fix

Before running the grid/search logic, take a full-page `ariaSnapshot` and scan for the chat header button. WhatsApp exposes it as either:
- `button "<chat name>"` (direct messages)
- `button "<chat name> <locale suffix>"` (groups, e.g. `greentap-sandbox clicca qui per info gruppo`)

Match either → chat is already open → return immediately.

Regex metacharacters in the chat name are escaped so `foo.bar` doesn't accidentally match `button "fooXbar"`.

## Tests

`npm test`: **138/138 pass** (+4 new fast-path unit tests covering direct chat, group with locale suffix, fall-through when header absent, and regex metacharacter escaping).

## Meta-e2e (live sandbox)

```
[r5] step: send (re-entry)       → ok
[r5] step: read (re-entry)       → ok (39 messages, marker found)
[r5] step: fetchImages (re-entry) → ok (1 download, no error)

{
  "pass": true,
  "markerInRead": true,
  "readMessageCount": 39,
  "downloadsCount": 1,
  "downloadedPath": ".../greentap-sandbox/13a3556f.jpg"
}
```

Before this PR: step 3 or 4 crashed with "Chat not found".

## Unblocks

- **R4**: `lib/e2e.js` image + link stages — can be un-skipped now. `runE2E` is exactly the shape that triggers the re-entry bug (multiple back-to-back commands on the same chat).
- Any future command that composes `send + read + fetchImages` naturally.

## PII

Clean. No changes to fixtures. Test fake page uses existing personas (Roberto Marini, Elena Conti, Ferragosto, greentap-sandbox).

## Test plan

- [x] Unit tests pass (138/138)
- [x] Live meta-e2e: re-entry on send → read → fetchImages all succeed
- [x] PII grep clean
- [ ] Maintainer independent review