### PR TITLE
fix(e2e): full roundtrip — preflight + image + link

### DIFF
--- a/lib/e2e.js
+++ b/lib/e2e.js
@@ -23,19 +23,40 @@ const FIXTURE_PNG = join(__dirname, "..", "test", "fixtures", "e2e", "sample.png
 
 function now() { return Date.now(); }
 
+/**
+ * Pre-flight: confirm the sandbox group is reachable by navigating to it.
+ *
+ * Earlier approaches via `chats()` (viewport-bound) or `search()` (its
+ * `textbox.first()` falls onto the compose textbox when a chat is
+ * already open) were both unreliable. Instead, just call `navigateToChat`
+ * directly — its R5 fast-path is a no-op if we're already in the
+ * sandbox, otherwise its grid-or-search logic handles cold state. If
+ * navigation succeeds, the sandbox exists and is open; if it throws
+ * "Chat not found", preflight fails with the same error path.
+ *
+ * Side effect: stages 2-4 begin with the sandbox chat already open.
+ * That's fine — `send`/`read`/`fetchImages` are now re-entrant safe.
+ */
 async function stagePreflight(page, localeConfig) {
   const start = now();
-  const rows = await commands.chats(page, localeConfig);
-  const sandbox = rows[0];
-  const expected = process.env.GREENTAP_E2E_CHAT || "greentap-sandbox";
-  const pass = rows.length === 1 && sandbox && sandbox.name === expected;
-  return {
-    stage: "preflight",
-    pass,
-    rowsVisible: rows.length,
-    duration_ms: now() - start,
-    error: pass ? undefined : `sandbox group not found — create a WhatsApp group named '${expected}' with only yourself as a member`,
-  };
+  const sandbox = process.env.GREENTAP_E2E_CHAT || "greentap-sandbox";
+  try {
+    await commands.navigateToChat(page, sandbox, localeConfig);
+    return {
+      stage: "preflight",
+      pass: true,
+      duration_ms: now() - start,
+    };
+  } catch (err) {
+    return {
+      stage: "preflight",
+      pass: false,
+      duration_ms: now() - start,
+      error:
+        `sandbox '${sandbox}' not reachable: ${err.message}. ` +
+        `Ensure a WhatsApp group named '${sandbox}' exists with only the maintainer as member.`,
+    };
+  }
 }
 
 function checkRateLimit() {
@@ -57,101 +78,80 @@ function writeLastRun() {
   writeFileSync(LAST_RUN_FILE, String(now()), { mode: 0o600 });
 }
 
+/**
+ * Hard-reset the page state. WA's image-preview overlay can linger after
+ * setInputFiles/Enter and intercept clicks on the compose box for the
+ * next stage. Pressing Escape repeatedly is unreliable — Escape can open
+ * unintended menus (verified empirically: 5x Escape from clean state
+ * opens 1 dialog). page.reload() is heavier (~3s) but gives a clean,
+ * authenticated chat-list state from which navigateToChat works
+ * deterministically.
+ */
+async function resetPageState(page) {
+  try {
+    await page.reload();
+    // Wait for chat list grid to be back. 15s upper bound covers cold
+    // WA loads; in steady state it's <2s.
+    await page.getByRole("grid").first().waitFor({ timeout: 15000 });
+  } catch { /* fall through; the next stage will surface the error */ }
+}
+
+/**
+ * Attach the fixture image and send.
+ *
+ * Earlier attempts called setInputFiles on the first
+ * `input[type="file"][accept*="image"]` in the page — that turned out
+ * to be the STICKER input, not the photo input. The fixture would be
+ * sent as an animated sticker rather than a photo.
+ *
+ * Correct flow:
+ *   1. Click "Allega" — the first button in contentinfo's compose toolbar.
+ *   2. The attach menu pops up with 8 items: Documento, Foto e video,
+ *      Fotocamera, Audio, Contatto, Sondaggio, Evento, Nuovo sticker.
+ *      Item 1 (icon `ic-filter-filled`) is "Photos & Videos". Picking
+ *      by icon name (visible in the menuitem's textContent) is
+ *      locale-agnostic and avoids accidentally selecting Nuovo sticker
+ *      (icon `wds-ic-sticker-*`).
+ *   3. Clicking that menuitem fires a native filechooser. Playwright
+ *      intercepts via `page.waitForEvent("filechooser")`. setFiles on
+ *      the chooser populates the photo preview dialog.
+ *   4. Enter submits the preview.
+ */
 async function sendFixtureImage(page, sandbox, fixturePath, localeConfig) {
-  // Skip navigation if we're already in the sandbox chat. The previous
-  // stage (text) leaves the page there; navigating again triggers the
-  // WA search-fallback path in navigateToChat which, with a chat open,
-  // picks up the compose textbox instead of the search box and types
-  // the chat name into the message. Detect by looking for the chat's
-  // header button in the current aria.
-  const aria = await page.locator(":root").ariaSnapshot();
-  const headerPattern = new RegExp(`button "${sandbox.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}(?: [^"]*)?"`);
-  const alreadyHere = headerPattern.test(aria);
-  if (!alreadyHere) {
-    await commands.navigateToChat(page, sandbox, localeConfig);
+  await commands.navigateToChat(page, sandbox, localeConfig);
+
+  // Open the attach menu.
+  const allegaButton = page
+    .getByRole("contentinfo")
+    .getByRole("button")
+    .first();
+  await allegaButton.click({ timeout: 5000 });
+  await new Promise((r) => setTimeout(r, 500));
+
+  // Find the "Photos & Videos" menuitem by icon name (locale-agnostic).
+  // ic-filter-filled is unique to that item in current WA Web; stickers
+  // use wds-ic-sticker-*, document uses ic-description-*, etc.
+  const photosIdx = await page.evaluate(() => {
+    const items = [...document.querySelectorAll('[role="menuitem"]')];
+    return items.findIndex((m) => /ic-filter-filled/.test(m.textContent || ""));
+  });
+  if (photosIdx === -1) {
+    throw new Error(
+      "Photos & Videos menuitem (icon ic-filter-filled) not found in attach menu",
+    );
   }
-  // WA's compose area has a hidden <input type="file" accept="image/*,video/*"/>
-  // nested under the paperclip. We target by accept attribute to be locale-agnostic.
-  const input = page.locator('input[type="file"][accept*="image"]').first();
-  await input.setInputFiles(fixturePath);
-  // A preview dialog appears; the send button is the primary action.
-  // WA exposes it as role=button with name varying by locale — match by the
-  // send-icon SVG via its aria-hidden container: use the "Enter" keystroke
-  // which is universally supported in the preview dialog.
+
+  // Set up the filechooser intercept BEFORE clicking — the click fires
+  // the event synchronously.
+  const fcPromise = page.waitForEvent("filechooser", { timeout: 8000 });
+  await page.getByRole("menuitem").nth(photosIdx).click();
+  const fileChooser = await fcPromise;
+  await fileChooser.setFiles(fixturePath);
+
+  // Preview dialog mounts; Enter submits (locale-agnostic).
+  await new Promise((r) => setTimeout(r, 1500));
   await page.keyboard.press("Enter");
-}
-
-async function stageImage(page, localeConfig, sandbox) {
-  const start = now();
-  if (!existsSync(FIXTURE_PNG)) {
-    return { stage: "image", pass: false, duration_ms: now() - start, error: `fixture missing: ${FIXTURE_PNG}` };
-  }
-  try {
-    await sendFixtureImage(page, sandbox, FIXTURE_PNG, localeConfig);
-  } catch (err) {
-    return { stage: "image", pass: false, duration_ms: now() - start, error: `attach+send failed: ${err.message}` };
-  }
-  // Wait for the image to appear in the message panel
-  await new Promise((r) => setTimeout(r, 3000));
-
-  // fetchImages is NOT on main yet at Plan E time — the image stage asserts
-  // only that the message containing an image is visible. PR #18's rebase
-  // commit extends this stage to call commands.fetchImages and assert the
-  // downloaded path.
-  let messages;
-  try {
-    messages = await commands.read(page, sandbox, { localeConfig });
-  } catch (err) {
-    return { stage: "image", pass: false, duration_ms: now() - start, error: `read after attach failed: ${err.message}` };
-  }
-  // Fallback marker: after sendFixtureImage, the most recent message from
-  // sender "You" should be within the last 3 rows. We can't identify image
-  // kind here (PR #18 adds that), so we assert a new "You" message exists
-  // that wasn't there before the stage started. Cheap proxy.
-  const lastYouRows = messages.slice(-5).filter((m) => m.sender === "You");
-  const pass = lastYouRows.length >= 1;
-  return {
-    stage: "image",
-    pass,
-    duration_ms: now() - start,
-    messagesInspected: messages.length,
-    note: "image-kind assertion deferred to PR #18 rebase (fetchImages not on main yet)",
-    error: pass ? undefined : "no new 'You' message after attach",
-  };
-}
-
-async function stageLink(page, localeConfig, sandbox) {
-  const start = now();
-  const marker = randomUUID();
-  const url = `https://example.com/e2e-${marker}`;
-  try {
-    await commands.send(page, sandbox, url, localeConfig);
-  } catch (err) {
-    return { stage: "link", pass: false, duration_ms: now() - start, error: `send failed: ${err.message}` };
-  }
-  // Preview rendering is not always immediate; 2s is a reasonable empirical window.
-  await new Promise((r) => setTimeout(r, 2000));
-
-  let messages;
-  try {
-    messages = await commands.read(page, sandbox, { localeConfig });
-  } catch (err) {
-    return { stage: "link", pass: false, duration_ms: now() - start, error: `read failed: ${err.message}` };
-  }
-  // Parser exposes links[] on each message ONLY after PR #17 lands. At Plan
-  // E time it's not on main. Fall back to asserting the text body contains
-  // the URL we sent. PR #17's rebase commit replaces this fallback with a
-  // links[0].href assertion.
-  const hit = messages.find((m) => m.text && m.text.includes(marker));
-  const pass = Boolean(hit);
-  return {
-    stage: "link",
-    pass,
-    duration_ms: now() - start,
-    messagesInspected: messages.length,
-    note: "links[] assertion deferred to PR #17 rebase",
-    error: pass ? undefined : `marker '${marker}' not found in read output`,
-  };
+  await new Promise((r) => setTimeout(r, 1500));
 }
 
 async function stageText(page, localeConfig, sandbox) {
@@ -162,7 +162,6 @@ async function stageText(page, localeConfig, sandbox) {
   } catch (err) {
     return { stage: "text", pass: false, duration_ms: now() - start, error: `send failed: ${err.message}` };
   }
-  // Brief wait for WA to echo the sent message back into the message panel
   await new Promise((r) => setTimeout(r, 1500));
   let messages;
   try {
@@ -181,13 +180,162 @@ async function stageText(page, localeConfig, sandbox) {
   };
 }
 
+async function stageImage(page, localeConfig, sandbox) {
+  const start = now();
+  if (!existsSync(FIXTURE_PNG)) {
+    return {
+      stage: "image",
+      pass: false,
+      duration_ms: now() - start,
+      error: `fixture missing: ${FIXTURE_PNG}`,
+    };
+  }
+
+  // Snapshot the imageId set BEFORE the send so we can detect the new
+  // arrival rather than just "any image exists" (which would let an
+  // attached-but-not-sent fixture pass on top of stale chat history).
+  let beforeIds = new Set();
+  try {
+    const beforeAria = await page.locator(":root").ariaSnapshot();
+    const beforeMsgs = (await import("./parser.js")).parseMessages(beforeAria, { localeConfig });
+    beforeIds = new Set(
+      beforeMsgs.filter((m) => m.kind === "image").map((m) => m.imageId),
+    );
+  } catch { /* if parser snapshot fails, fall back to "any image" check */ }
+
+  try {
+    await sendFixtureImage(page, sandbox, FIXTURE_PNG, localeConfig);
+  } catch (err) {
+    return {
+      stage: "image",
+      pass: false,
+      duration_ms: now() - start,
+      error: `attach+send failed: ${err.message}`,
+    };
+  }
+  await new Promise((r) => setTimeout(r, 3000));
+
+  // Re-parse to find the newly added image message.
+  let newImageId = null;
+  try {
+    const afterAria = await page.locator(":root").ariaSnapshot();
+    const afterMsgs = (await import("./parser.js")).parseMessages(afterAria, { localeConfig });
+    const newImg = afterMsgs
+      .filter((m) => m.kind === "image" && !beforeIds.has(m.imageId))
+      .pop();
+    newImageId = newImg?.imageId ?? null;
+  } catch { /* fall through; downloads check below covers the case */ }
+
+  if (!newImageId) {
+    return {
+      stage: "image",
+      pass: false,
+      duration_ms: now() - start,
+      error:
+        "no new image-kind message detected after attach+send — likely the file input did not submit (preview overlay stuck or wrong input targeted)",
+    };
+  }
+
+  let downloads;
+  try {
+    downloads = await commands.fetchImages(page, sandbox, {
+      localeConfig,
+      limit: 1,
+    });
+  } catch (err) {
+    return {
+      stage: "image",
+      pass: false,
+      duration_ms: now() - start,
+      newImageId,
+      error: `fetchImages failed: ${err.message}`,
+    };
+  }
+  // Match the just-sent image by imageId. fetchImages with limit:1
+  // returns the most-recent image-kind message, so it should match.
+  const top = downloads.find((d) => d.imageId === newImageId) ?? downloads[0];
+  const pass = Boolean(
+    top && top.path && !top.error && top.imageId === newImageId,
+  );
+  return {
+    stage: "image",
+    pass,
+    duration_ms: now() - start,
+    newImageId,
+    imagePath: top?.path ?? null,
+    mimeType: top?.mimeType ?? null,
+    // Surfaced for the agent caller: after stage passes, the runtime
+    // operator (or supervising agent) is expected to Read() the path
+    // and confirm the fixture text is legible. CONTRIBUTING.md docs
+    // this as the multimodal verification step.
+    multimodalCheck: pass
+      ? "Read the imagePath and confirm 'GREENTAP-E2E' is legible"
+      : null,
+    error: pass
+      ? undefined
+      : top?.error ?? "fetched image does not match newImageId",
+  };
+}
+
+async function stageLink(page, localeConfig, sandbox) {
+  const start = now();
+  const marker = randomUUID();
+  const url = `https://example.com/e2e-${marker}`;
+  try {
+    await commands.send(page, sandbox, url, localeConfig);
+  } catch (err) {
+    return {
+      stage: "link",
+      pass: false,
+      duration_ms: now() - start,
+      error: `send failed: ${err.message}`,
+    };
+  }
+  // Preview rendering not always immediate.
+  await new Promise((r) => setTimeout(r, 2000));
+
+  let messages;
+  try {
+    messages = await commands.read(page, sandbox, {
+      localeConfig,
+      withLinks: true,
+    });
+  } catch (err) {
+    return {
+      stage: "link",
+      pass: false,
+      duration_ms: now() - start,
+      error: `read failed: ${err.message}`,
+    };
+  }
+  const hit = messages.find(
+    (m) =>
+      m.links && m.links.some((l) => l.href && l.href.includes(marker)),
+  );
+  const pass = Boolean(hit);
+  return {
+    stage: "link",
+    pass,
+    duration_ms: now() - start,
+    messagesInspected: messages.length,
+    hrefFound: hit ? hit.links[0].href : null,
+    error: pass
+      ? undefined
+      : `marker '${marker}' not found in any message's links[]`,
+  };
+}
+
 /**
  * Runs the full e2e sequence. Returns { pass, exitCode, stages, rateLimitedForSec? }.
  * exitCode: 0 pass, 1 fail, 2 sandbox missing, 3 rate limited.
  */
 export async function runE2E({ page, localeConfig }) {
   if (!isE2EMode()) {
-    return { pass: false, exitCode: 1, stages: [{ stage: "init", pass: false, error: "GREENTAP_E2E=1 not set" }] };
+    return {
+      pass: false,
+      exitCode: 1,
+      stages: [{ stage: "init", pass: false, error: "GREENTAP_E2E=1 not set" }],
+    };
   }
 
   const rateSec = checkRateLimit();
@@ -198,6 +346,10 @@ export async function runE2E({ page, localeConfig }) {
   const stages = [];
   const sandbox = process.env.GREENTAP_E2E_CHAT || "greentap-sandbox";
 
+  // Reset page to a known clean state. Previous CLI invocations may
+  // have left attachment previews, search overlays, or menus open.
+  await resetPageState(page);
+
   const pre = await stagePreflight(page, localeConfig);
   stages.push(pre);
   if (!pre.pass) return { pass: false, exitCode: 2, stages };
@@ -206,28 +358,18 @@ export async function runE2E({ page, localeConfig }) {
   stages.push(text);
   if (!text.pass) return { pass: false, exitCode: 1, stages };
 
-  // Image and link stages are implemented but disabled until PR #16
-  // (navigateToChat robustness) lands on main. Calling navigateToChat
-  // again with a chat already open currently picks up the message-panel
-  // grid instead of the chat list, falling back to a broken search path.
-  // The rebase commit for PR #18 (image download) and PR #17 (links[])
-  // will flip these skipped stages to active.
-  stages.push({
-    stage: "image",
-    pass: true,
-    skipped: true,
-    reason: "disabled until PR #16 (navigateToChat robustness) merges; re-enabled by PR #18 rebase",
-  });
-  stages.push({
-    stage: "link",
-    pass: true,
-    skipped: true,
-    reason: "disabled until PR #16 (navigateToChat robustness) merges; re-enabled by PR #17 rebase",
-  });
-  // Silence unused-symbol lints for the implementations we're preserving
-  // for the rebase. (Intentional; tagged with suppression instead of
-  // deleting the functions.)
-  void stageImage; void stageLink;
+  const image = await stageImage(page, localeConfig, sandbox);
+  stages.push(image);
+  if (!image.pass) return { pass: false, exitCode: 1, stages };
+
+  // After image stage, WA leaves the attachment-preview overlay state
+  // partially mounted (verified: Escape opens unintended dialogs from
+  // clean state, so we can't dismiss). Reload page → clean compose.
+  await resetPageState(page);
+
+  const link = await stageLink(page, localeConfig, sandbox);
+  stages.push(link);
+  if (!link.pass) return { pass: false, exitCode: 1, stages };
 
   writeLastRun();
   return { pass: true, exitCode: 0, stages };

--- a/lib/e2e.js
+++ b/lib/e2e.js
@@ -131,15 +131,27 @@ async function sendFixtureImage(page, sandbox, fixturePath, localeConfig) {
   // Find the "Photos & Videos" menuitem by icon name (locale-agnostic).
   // ic-filter-filled is unique to that item in current WA Web; stickers
   // use wds-ic-sticker-*, document uses ic-description-*, etc.
-  const photosIdx = await page.evaluate(() => {
+  // Assert uniqueness — if WA ever adds a second menuitem with the same
+  // icon, fail loudly rather than silently picking the first match
+  // (could be the wrong one).
+  const photosMatch = await page.evaluate(() => {
     const items = [...document.querySelectorAll('[role="menuitem"]')];
-    return items.findIndex((m) => /ic-filter-filled/.test(m.textContent || ""));
+    const indices = items
+      .map((m, i) => (/ic-filter-filled/.test(m.textContent || "") ? i : -1))
+      .filter((i) => i >= 0);
+    return { indices, total: items.length };
   });
-  if (photosIdx === -1) {
+  if (photosMatch.indices.length === 0) {
     throw new Error(
       "Photos & Videos menuitem (icon ic-filter-filled) not found in attach menu",
     );
   }
+  if (photosMatch.indices.length > 1) {
+    throw new Error(
+      `ic-filter-filled matched ${photosMatch.indices.length} menuitems (expected 1) — WA UI may have changed; refusing to guess`,
+    );
+  }
+  const photosIdx = photosMatch.indices[0];
 
   // Set up the filechooser intercept BEFORE clicking — the click fires
   // the event synchronously.
@@ -313,12 +325,16 @@ async function stageLink(page, localeConfig, sandbox) {
       m.links && m.links.some((l) => l.href && l.href.includes(marker)),
   );
   const pass = Boolean(hit);
+  // Surface the actual matching href, not just links[0] — if a message
+  // has multiple links the marker could be at a higher index.
+  const matchingHref =
+    hit && hit.links.find((l) => l.href.includes(marker))?.href;
   return {
     stage: "link",
     pass,
     duration_ms: now() - start,
     messagesInspected: messages.length,
-    hrefFound: hit ? hit.links[0].href : null,
+    hrefFound: matchingHref ?? null,
     error: pass
       ? undefined
       : `marker '${marker}' not found in any message's links[]`,


### PR DESCRIPTION
## Summary

The e2e harness landed in #19 with the image and link stages stubbed as skipped, awaiting #16/#17/#18. Those landed, but un-skipping exposed three more bugs:

1. **Preflight is viewport-bound.** `commands.chats()` only sees rows currently rendered in the chat-list sidebar. When other chats receive activity, the sandbox gets pushed below the fold — filterToSandbox returns `[]` and preflight fails even though the group exists.
2. **`commands.search()` re-entry.** Its `textbox.first()` falls onto the compose textbox when any chat is already open — same family of bug as the navigateToChat re-entry fixed by #24.
3. **`sendFixtureImage` attached to the STICKER input.** `input[type="file"][accept*="image"]` in current WA Web is the sticker input, not the photo input. The fixture went out as a sticker, fetchImages never saw a new image-kind message, and the previous lenient assertion ("any image exists") let it pass with a stale cached image.

## Fixes

1. **Preflight via `navigateToChat`.** Idempotent (R5 fast-path), handles all three states (already in sandbox / sandbox in viewport / sandbox in search). If the call succeeds, the sandbox is reachable; if it throws "Chat not found", preflight fails.
2. **Page reload between image and link stages.** Escape is unsafe (it can open unintended menus); reload gives a clean compose state.
3. **Proper photo-attach flow.** Click "Allega" → find "Photos & Videos" menuitem by **icon name `ic-filter-filled`** (locale-agnostic, distinct from sticker icons `wds-ic-sticker-*`) → Playwright `filechooser` intercept → setFiles → Enter to submit.
4. **Stricter image assertion.** Snapshot the imageId set BEFORE the send, assert the post-send fetchImages output contains a new id. Catches "stuck preview / wrong input" failures the previous fallback hid.
5. **Link assertion uses `msg.links[0].href`** (the R3 contract).

## Meta-e2e (live sandbox)

```
{
  "pass": true,
  "exitCode": 0,
  "stages": [
    { "stage": "preflight", "pass": true, "duration_ms": 2396 },
    { "stage": "text",      "pass": true, "messagesInspected": 39 },
    { "stage": "image",     "pass": true, "newImageId": "16b07d1f",
      "imagePath": ".../greentap-sandbox/16b07d1f.jpg",
      "mimeType": "image/jpeg",
      "multimodalCheck": "Read the imagePath and confirm 'GREENTAP-E2E' is legible" },
    { "stage": "link",      "pass": true,
      "hrefFound": "https://example.com/e2e-ac040c75-c1a6-4e8b-8aeb-50f8bf6336de" }
  ]
}
```

Multimodal Read on the downloaded `16b07d1f.jpg` confirmed `GREENTAP-E2E` text legible. The image is fresh-from-this-run (new imageId, downloaded live), not a cached older fixture.

## Tests

- `npm test`: 138/138 pass
- The harness changes are in lib/e2e.js (integration-only). All four stages are now fully end-to-end exercised.

## Sticker vs photo (per maintainer note)

Explicitly: the new `sendFixtureImage` does NOT touch any sticker input. It uses `Allega → Foto e video` menuitem (icon `ic-filter-filled`), which fires a filechooser. Sticker inputs would be `wds-ic-sticker-*` icons — those are not selected.

## Test plan

- [x] `npm test` green
- [x] Live meta-e2e: 4/4 stages pass
- [x] Multimodal Read of the imagePath confirms fixture text legible
- [x] PII grep clean
- [ ] Maintainer independent review

## What this completes

End of the repair sequence: R1 (#21 UA), R3 (#22 links merge), R2 (#23 fetchImages), R5 (#24 navigate re-entry), R4 (this PR). The "features that don't work" list from earlier is now resolved.