### PR TITLE
fix(send): handle newlines as Shift+Enter to keep multi-line messages in one bubble

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -502,7 +502,25 @@ export async function send(page, chatName, message, localeConfig, index) {
   await compose.waitFor({ timeout: 5000 });
   await compose.click();
   await humanDelay(300, 600);
-  await page.keyboard.type(message, { delay: 30 });
+
+  // Multi-line handling: a literal "\n" in the typed string is treated by
+  // WhatsApp Web as a submit-equivalent inside the compose textbox, which
+  // would fan out a 3-line message into 3 separate bubbles. The intended
+  // "newline within a single message" key is Shift+Enter. So we split the
+  // message on newline boundaries, type each segment, and press
+  // Shift+Enter between segments. Normalize CRLF to LF first so messages
+  // pasted from Windows-style sources behave the same. The final Enter
+  // submission happens via the Send button click below — keep both paths
+  // in sync.
+  const segments = message.replace(/\r\n/g, "\n").split("\n");
+  for (let i = 0; i < segments.length; i++) {
+    if (segments[i].length > 0) {
+      await page.keyboard.type(segments[i], { delay: 30 });
+    }
+    if (i < segments.length - 1) {
+      await page.keyboard.press("Shift+Enter");
+    }
+  }
 
   // Wait for Send button — it replaces the voice message button in contentinfo after typing.
   // The send button is the last button inside contentinfo when text is present.

--- a/test/send-newline.test.js
+++ b/test/send-newline.test.js
@@ -1,0 +1,225 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import * as commands from "../lib/commands.js";
+
+/**
+ * Build a fake Playwright `page` for exercising `send()` end-to-end
+ * without a real browser. The fake records every `keyboard.type` and
+ * `keyboard.press` call in arrival order, so tests can assert on the
+ * exact key-press pattern emitted for multi-line messages.
+ *
+ * The page is wired so that:
+ *   - The chat header banner already shows the target chat (fast-path
+ *     in navigateToChat returns immediately, no grid/search interaction).
+ *   - The post-send aria check sees the message text, so the verification
+ *     warning does not fire.
+ *   - The compose `textContent()` returns "" after send, so the "still in
+ *     compose box" failure does not fire.
+ *
+ * @param {string} chatName - Name displayed in the header banner.
+ * @param {string} expectedAriaSnippet - Snippet to embed in the post-send
+ *   aria so the snippet-match check passes (default: chatName).
+ */
+function makeSendFakePage(chatName, expectedAriaSnippet = chatName) {
+  const calls = [];
+  // The post-send aria must contain a snippet of the typed message so the
+  // snippet-match warning does not fire. Build a snapshot that contains
+  // both the chat header (matched by the header-button regex) and the
+  // typed text once the message is "delivered".
+  const ariaText =
+    `- banner:\n  - button "${chatName}"\n` +
+    `- contentinfo:\n  - textbox "Type a message"\n` +
+    `- text: "${expectedAriaSnippet}"\n`;
+
+  const composeTextbox = {
+    waitFor: async () => {},
+    click: async () => {},
+    textContent: async () => "",
+  };
+
+  const sendButton = {
+    click: async () => {
+      calls.push({ kind: "sendBtnClick" });
+    },
+  };
+
+  const contentinfoButtons = {
+    count: async () => 1,
+    last: () => sendButton,
+  };
+
+  const contentinfo = {
+    getByRole: (role) => {
+      if (role === "textbox") return composeTextbox;
+      if (role === "button") return contentinfoButtons;
+      return composeTextbox;
+    },
+  };
+
+  // Fast-path returns immediately when this banner exposes the chat name.
+  const bannerLocator = {
+    first: () => bannerLocator,
+    last: () => bannerLocator,
+    ariaSnapshot: async () => `- banner:\n  - button "${chatName}"`,
+  };
+
+  const page = {
+    getByRole: (role) => {
+      if (role === "contentinfo") return contentinfo;
+      if (role === "banner") return bannerLocator;
+      // Other roles (grid, textbox, gridcell) shouldn't be touched once
+      // the fast-path fires, but provide stubs in case they are.
+      return {
+        first: () => ({
+          waitFor: async () => {},
+          click: async () => {},
+          isVisible: async () => false,
+          ariaSnapshot: async () => "",
+        }),
+        last: () => ({}),
+      };
+    },
+    locator: () => ({
+      ariaSnapshot: async () => ariaText,
+    }),
+    keyboard: {
+      type: async (text, _opts) => {
+        calls.push({ kind: "type", text });
+      },
+      press: async (key) => {
+        calls.push({ kind: "press", key });
+      },
+    },
+    evaluate: async () => null,
+    _calls: calls,
+  };
+  return page;
+}
+
+describe("send: multi-line newline handling", () => {
+  it("single-line message: 1 type, 0 Shift+Enter, no fan-out", async () => {
+    const page = makeSendFakePage("Roberto Marini", "Ciao");
+    await commands.send(page, "Roberto Marini", "Ciao", null, undefined);
+
+    const types = page._calls.filter((c) => c.kind === "type");
+    const shiftEnters = page._calls.filter(
+      (c) => c.kind === "press" && c.key === "Shift+Enter",
+    );
+
+    assert.equal(types.length, 1, "should have exactly 1 type call");
+    assert.equal(types[0].text, "Ciao");
+    assert.equal(shiftEnters.length, 0, "no Shift+Enter for single-line");
+  });
+
+  it("3-line message: 3 type calls, 2 Shift+Enter between segments", async () => {
+    const page = makeSendFakePage("Roberto Marini", "line1");
+    await commands.send(
+      page,
+      "Roberto Marini",
+      "line1\nline2\nline3",
+      null,
+      undefined,
+    );
+
+    // Walk the call sequence: each non-final segment must be followed by
+    // a Shift+Enter before the next segment is typed.
+    const seq = page._calls.filter(
+      (c) => c.kind === "type" || (c.kind === "press" && c.key === "Shift+Enter"),
+    );
+
+    assert.deepEqual(
+      seq,
+      [
+        { kind: "type", text: "line1" },
+        { kind: "press", key: "Shift+Enter" },
+        { kind: "type", text: "line2" },
+        { kind: "press", key: "Shift+Enter" },
+        { kind: "type", text: "line3" },
+      ],
+      "should interleave types and Shift+Enter in the right order",
+    );
+
+    // Final submit goes through the Send button click, not via Enter on
+    // the keyboard — guard that path so a regression to "type the whole
+    // string + Enter" can't slip through.
+    const enters = page._calls.filter(
+      (c) => c.kind === "press" && c.key === "Enter",
+    );
+    assert.equal(enters.length, 0, "must not press a bare Enter (would submit early)");
+    const sendClicks = page._calls.filter((c) => c.kind === "sendBtnClick");
+    assert.equal(sendClicks.length, 1, "Send button should be clicked exactly once");
+  });
+
+  it("CRLF line endings are normalized to a single newline", async () => {
+    const page = makeSendFakePage("Roberto Marini", "alpha");
+    await commands.send(
+      page,
+      "Roberto Marini",
+      "alpha\r\nbeta",
+      null,
+      undefined,
+    );
+
+    const seq = page._calls.filter(
+      (c) => c.kind === "type" || (c.kind === "press" && c.key === "Shift+Enter"),
+    );
+
+    assert.deepEqual(seq, [
+      { kind: "type", text: "alpha" },
+      { kind: "press", key: "Shift+Enter" },
+      { kind: "type", text: "beta" },
+    ]);
+  });
+
+  it("blank line in the middle still produces a single bubble (empty segment skipped, Shift+Enter preserved)", async () => {
+    // "a\n\nb" — the empty middle segment must NOT be typed (would be a
+    // no-op anyway) but the boundaries must still emit two Shift+Enter
+    // presses to preserve the visual blank line.
+    const page = makeSendFakePage("Roberto Marini", "a");
+    await commands.send(page, "Roberto Marini", "a\n\nb", null, undefined);
+
+    const seq = page._calls.filter(
+      (c) => c.kind === "type" || (c.kind === "press" && c.key === "Shift+Enter"),
+    );
+
+    assert.deepEqual(seq, [
+      { kind: "type", text: "a" },
+      { kind: "press", key: "Shift+Enter" },
+      { kind: "press", key: "Shift+Enter" },
+      { kind: "type", text: "b" },
+    ]);
+  });
+
+  it("empty message does not crash and types nothing", async () => {
+    // Empty message is a degenerate input — the function should not
+    // explode. The Send button click happens regardless; WhatsApp Web's
+    // own UI will no-op it, but we guard against a JS crash here.
+    const page = makeSendFakePage("Roberto Marini", "");
+    await assert.doesNotReject(() =>
+      commands.send(page, "Roberto Marini", "", null, undefined),
+    );
+    const types = page._calls.filter((c) => c.kind === "type");
+    const shiftEnters = page._calls.filter(
+      (c) => c.kind === "press" && c.key === "Shift+Enter",
+    );
+    assert.equal(types.length, 0, "no type call for empty input");
+    assert.equal(shiftEnters.length, 0, "no Shift+Enter for empty input");
+  });
+
+  it("trailing newline does not emit a phantom empty type call", async () => {
+    // "hi\n" splits to ["hi", ""]. The empty trailing segment must be
+    // skipped (no zero-length type) but a Shift+Enter must still be
+    // emitted between them.
+    const page = makeSendFakePage("Roberto Marini", "hi");
+    await commands.send(page, "Roberto Marini", "hi\n", null, undefined);
+
+    const seq = page._calls.filter(
+      (c) => c.kind === "type" || (c.kind === "press" && c.key === "Shift+Enter"),
+    );
+
+    assert.deepEqual(seq, [
+      { kind: "type", text: "hi" },
+      { kind: "press", key: "Shift+Enter" },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

`greentap send <chat> "line1\nline2\nline3"` was fanning out into 3 separate WhatsApp bubbles because WhatsApp Web treats `\n` typed into compose as a submit-equivalent. Net effect: spam-look perceived by recipients, ranged confusion in agent workflows that compose multi-line messages.

## Fix

In `send()`:
- Normalize CRLF (`\r\n` → `\n`)
- Split message on `\n`
- For each non-empty segment: `keyboard.type(segment, { delay: 30 })`
- Between segments: `keyboard.press("Shift+Enter")` (WA's "newline within message")
- Final submission unchanged — uses the existing Send-button click (no bare Enter, ever)

Empty segments produce a `Shift+Enter` boundary without a phantom `type` call, so `"a\n\nb"` correctly yields a single bubble with a visual blank line.

## Tests

`npm test`: 145 passing, 0 failing (+6 unit tests in `test/send-newline.test.js`):
- single-line: 1 type, 0 shift+enter
- 3-line: 3 types interleaved with 2 shift+enter
- CRLF: treated as single newline
- mid-blank-line: shift+enter without intervening type
- empty message: doesn't crash
- trailing newline: no phantom segment
- Regression guard: bare Enter is **never** pressed (would submit early)

## Live meta-e2e (sandbox)

Sent a 3-line message with a marker UUID. Read back:
\`\`\`json
{ "pass": true, "bubbleCount": 1, "containsAllLines": true, "expected": "1 bubble containing all 3 lines" }
\`\`\`

One bubble, all three lines present in `text`, sender `"You"`. Before this fix the same message would have produced 3 bubbles.

## Source

Maintainer-reported usability bug (multi-line sends mis-fanned). Q1 of v0.4.0 quality batch.

## Test plan

- [x] `npm test` green
- [x] Live multi-line send → single bubble verified
- [x] PII grep clean (no real names, no private URLs, no task tracker IDs)
- [ ] Maintainer independent review