### PR TITLE
feat: greentap whoami + locale-stable timestamps + null instead of empty

### DIFF
--- a/greentap.js
+++ b/greentap.js
@@ -14,6 +14,7 @@
  *   greentap search <query> [--json] — Search chats
  *   greentap snapshot [SCOPE] [--chat NAME] — Dump raw aria snapshot
  *   greentap e2e                — Run round-trip verification against sandbox (GREENTAP_E2E=1)
+ *   greentap whoami [--json]    — Show the logged-in account's name + phone
  *   greentap status             — Show daemon status
  *   greentap daemon stop        — Stop the daemon
  */
@@ -185,6 +186,16 @@ async function cmdE2E() {
   process.exit(result.exitCode);
 }
 
+async function cmdWhoami(json) {
+  const result = await withDaemon((page) => commands.whoami(page));
+  if (json) {
+    console.log(JSON.stringify(result));
+  } else {
+    console.log(`Name:  ${result.name ?? "(not detected)"}`);
+    console.log(`Phone: ${result.phone ?? "(not detected)"}`);
+  }
+}
+
 function cmdStatus() {
   const status = daemonStatus();
   if (status.running) {
@@ -310,6 +321,9 @@ try {
       await cmdE2E();
       break;
     }
+    case "whoami":
+      await cmdWhoami(args.includes("--json"));
+      break;
     case "status":
       cmdStatus();
       break;
@@ -336,6 +350,7 @@ Commands:
   search <query> [--json]                      Search chats
   snapshot [SCOPE] [--chat NAME]               Dump aria snapshot (full|chats|messages|compose)
   e2e                                          Run round-trip verification (GREENTAP_E2E=1 required)
+  whoami [--json]                              Show the logged-in account's name + phone
   status                                       Show daemon status
   daemon stop                                  Stop the daemon
 

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -281,6 +281,11 @@ async function scrollAndCollect(page, localeConfig) {
   let lastFirstKey = null;
   let exitReason = "max_iterations";
   const startTime = Date.now();
+  // Capture a single `now` for the entire scroll session — every iteration's
+  // relative-date resolution ("Ieri" / "Yesterday") MUST anchor to the same
+  // moment. Otherwise a scroll that crosses local midnight would split a
+  // single conversation across two calendar days.
+  const readNow = new Date();
   const MAX_ITERATIONS = 50;
   const TIMEOUT_MS = 30000;
 
@@ -291,7 +296,7 @@ async function scrollAndCollect(page, localeConfig) {
     }
 
     const aria = await page.locator(":root").ariaSnapshot();
-    const msgs = parseMessages(aria, { localeConfig });
+    const msgs = parseMessages(aria, { localeConfig, now: readNow });
     iterations.push(msgs);
 
     const firstKey = msgs.length > 0 ? dedupKey(msgs[0]) : null;
@@ -465,7 +470,10 @@ export async function read(page, chatName, { scroll = false, localeConfig, index
     return scrollAndCollect(page, localeConfig);
   }
   const aria = await page.locator(":root").ariaSnapshot();
-  const messages = parseMessages(aria, { localeConfig });
+  // Capture `now` at read time so relative-date separators ("Ieri" / "Yesterday")
+  // resolve deterministically against the snapshot's read moment, not against
+  // a slightly-later parse moment that could fall on the next calendar day.
+  const messages = parseMessages(aria, { localeConfig, now: new Date() });
   if (!withLinks) return messages;
 
   // Immediately collect DOM links while the same view is still mounted.
@@ -560,7 +568,9 @@ export async function pollResults(page, chatName, { localeConfig, index } = {}) 
       polls = found_polls;
     }
 
-    // Check scroll stability (same first message = can't go further)
+    // Check scroll stability (same first message = can't go further).
+    // No locale/now needed here — we only key on sender|time|text snippets,
+    // never on the resolved timestamp.
     const msgs = parseMessages(aria);
     const firstKey = msgs.length > 0 ? dedupKey(msgs[0]) : null;
     if (firstKey && firstKey === lastFirstKey) {
@@ -654,7 +664,9 @@ export async function fetchImages(page, chatName, { localeConfig, index, limit =
 
   // 1. Parse aria to identify image messages + their order within the row area.
   const aria = await page.locator(":root").ariaSnapshot();
-  const allMsgs = parseMessages(aria, { localeConfig });
+  // Pass `now` so any relative-date separator above the image rows resolves
+  // deterministically against the read moment.
+  const allMsgs = parseMessages(aria, { localeConfig, now: new Date() });
   const images = allMsgs.filter((m) => m.kind === "image").slice(-limit);
   if (images.length === 0) return [];
 
@@ -749,6 +761,120 @@ export async function fetchImages(page, chatName, { localeConfig, index, limit =
     });
   }
   return results;
+}
+
+/**
+ * Identify the WhatsApp account currently logged into the browser.
+ *
+ * Returns `{ name, phone }` — either field may be `null` if it could not be
+ * detected. Both being `null` is graceful degradation, not an error.
+ *
+ * Algorithm (locale-agnostic):
+ *   1. Locate the sidebar profile button by DOM signal — it's the only
+ *      `<button>` whose child `<img>` has a `whatsapp.net` source (the
+ *      account's profile picture). The button's aria-label is locale-
+ *      specific ("Tu" / "You") so we ignore it.
+ *   2. Click it. WhatsApp Web opens a settings menu where the FIRST
+ *      `heading [level=2]` is the account's display name.
+ *   3. Click the first `listitem` button inside that menu — opens the
+ *      "Edit profile" pane. There, the phone number appears as a `text:`
+ *      node prefixed with a locale-specific label (e.g. "Phone +1…"
+ *      / "Telefono +XX…"). We extract via regex on `+\d` patterns — the
+ *      phone is the only `+digits` text in the pane.
+ *   4. Press Escape twice to close both panes — restores the chat list
+ *      view that other commands assume.
+ *
+ * Failures degrade quietly: if any DOM step fails, the corresponding field
+ * is `null`. We always attempt to close panes.
+ */
+export async function whoami(page) {
+  let name = null;
+  let phone = null;
+  let openedPanes = 0;
+
+  try {
+    // Step 1 — find profile button by DOM signal.
+    const profileBtnFound = await page.evaluate(() => {
+      const buttons = [...document.querySelectorAll('button[aria-label]')];
+      for (const b of buttons) {
+        const img = b.querySelector("img");
+        if (img && img.src && img.src.includes(".whatsapp.net")) {
+          b.click();
+          return true;
+        }
+      }
+      return false;
+    });
+
+    if (!profileBtnFound) {
+      console.error("[whoami] profile button not found in sidebar; account identity could not be detected.");
+      return { name: null, phone: null };
+    }
+    openedPanes++;
+    await new Promise((r) => setTimeout(r, 800));
+
+    // Step 2 — display name = first level-2 heading after first banner.
+    // We scan the whole aria; the *first* level-2 heading is the user's
+    // display name (the sidebar header above the settings menu).
+    // The "WhatsApp" wordmark heading also exists but appears later inside
+    // a nested banner block.
+    const ariaMenu = await page.locator(":root").ariaSnapshot();
+    const headingMatch = ariaMenu.match(/- heading "([^"]+)" \[level=2\]/);
+    if (headingMatch) {
+      const candidate = headingMatch[1].trim();
+      // Filter out the "WhatsApp" wordmark heading — it's the only known
+      // non-name level-2 heading on this view.
+      if (candidate.toLowerCase() !== "whatsapp") {
+        name = candidate;
+      }
+    }
+
+    // Step 3 — drill into "Edit profile" pane to find phone.
+    try {
+      const firstListItem = page.getByRole("listitem").first();
+      const profileBtn = firstListItem.getByRole("button").first();
+      await profileBtn.click({ timeout: 3000 });
+      openedPanes++;
+      await new Promise((r) => setTimeout(r, 800));
+
+      const ariaProfile = await page.locator(":root").ariaSnapshot();
+      // Phone is a `text:` node with a leading "+" then digits/spaces/dashes.
+      // Restrict to the first 50 lines or so to avoid matching phone numbers
+      // in chat content (e.g. system messages "X ha aggiunto +XX …").
+      const profileLines = ariaProfile.split("\n").slice(0, 60);
+      for (const line of profileLines) {
+        const m = line.match(/- text:\s*\S+\s*(\+\d[\d\s\-]{6,})\s*$/);
+        if (m) {
+          phone = m[1].trim();
+          break;
+        }
+      }
+      // Fallback: bare phone with no preceding label
+      if (!phone) {
+        for (const line of profileLines) {
+          const m = line.match(/- text:\s*(\+\d[\d\s\-]{6,})\s*$/);
+          if (m) {
+            phone = m[1].trim();
+            break;
+          }
+        }
+      }
+    } catch (err) {
+      console.error("[whoami] could not open profile pane:", err?.message);
+    }
+  } finally {
+    // Always try to close panes so the caller's chat-list state is restored.
+    for (let i = 0; i < openedPanes; i++) {
+      try {
+        await page.keyboard.press("Escape");
+        await new Promise((r) => setTimeout(r, 250));
+      } catch {
+        // ignore
+      }
+    }
+  }
+
+  return { name, phone };
 }
 
 export async function snapshot(page, scope, chatName, localeConfig) {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -225,13 +225,16 @@ function parseDateSeparator(text, locale, now) {
 
 /**
  * Format a date + HH:MM time as "YYYY-MM-DD HH:MM".
- * Returns "" if either argument is missing.
+ * Returns `null` if either argument is missing — callers must treat
+ * "no timestamp" as a distinct value, not as the empty string. The
+ * empty-string sentinel was a footgun: agents check `if (msg.timestamp)`
+ * which would hide both genuine "no date" and accidental empty strings.
  * @param {Date|null} date
  * @param {string} time
- * @returns {string}
+ * @returns {string|null}
  */
 function formatTimestamp(date, time) {
-  if (!date || !time) return "";
+  if (!date || !time) return null;
   const y = date.getFullYear();
   const m = String(date.getMonth() + 1).padStart(2, "0");
   const d = String(date.getDate()).padStart(2, "0");

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -448,3 +448,162 @@ describe("CLI arg parsing: --index for send", () => {
     assert.equal(sendIndex, undefined);
   });
 });
+
+// --- whoami ---
+
+describe("whoami", () => {
+  /**
+   * Build a mock page where:
+   *   - `page.evaluate(fn)` runs the inline DOM probe in a tiny
+   *     simulated DOM (we only need to satisfy the profile-button shape).
+   *   - `page.locator(":root").ariaSnapshot()` returns canned snapshots
+   *     in sequence: first call = settings menu, second call = profile pane.
+   */
+  function makeWhoamiPage({ profileBtnExists = true, ariaMenu, ariaProfile }) {
+    let ariaCallIdx = 0;
+    const ariaSnapshots = [ariaMenu, ariaProfile];
+
+    const chainable = () => ({
+      waitFor: async () => {},
+      filter: () => chainable(),
+      click: async () => {},
+      first: () => chainable(),
+      last: () => chainable(),
+      count: async () => 1,
+      isVisible: async () => true,
+      ariaSnapshot: async () => ariaSnapshots[Math.min(ariaCallIdx, ariaSnapshots.length - 1)],
+      getByRole: () => chainable(),
+    });
+
+    return {
+      locator: () => ({
+        ariaSnapshot: async () => {
+          const snap = ariaSnapshots[Math.min(ariaCallIdx, ariaSnapshots.length - 1)];
+          ariaCallIdx++;
+          return snap;
+        },
+      }),
+      getByRole: () => chainable(),
+      keyboard: {
+        press: async () => {},
+        type: async () => {},
+      },
+      // The whoami DOM probe runs `(() => { const buttons = ...; ... })()`.
+      // We can't run the real DOM, so we short-circuit: return `true` when
+      // a profile button is supposed to exist, `false` otherwise.
+      evaluate: async (fn) => {
+        // Inspect the function source to decide the return shape.
+        const src = String(fn);
+        if (src.includes("button[aria-label]") && src.includes("whatsapp.net")) {
+          return profileBtnExists;
+        }
+        return null;
+      },
+    };
+  }
+
+  const ARIA_MENU_IT = `- document:
+  - banner:
+    - button "Tu" [pressed]:
+      - img
+  - banner:
+    - heading "Mario Rossi" [level=2]
+  - listbox:
+    - listitem:
+      - button "Profilo Nome, immagine del profilo"
+  - banner:
+    - banner:
+      - heading "WhatsApp" [level=2]:
+        - img "wa-wordmark-refreshed"
+`;
+
+  const ARIA_PROFILE_IT = `- document:
+  - banner:
+    - button "Tu" [pressed]:
+      - img
+  - banner:
+    - button "Indietro"
+    - heading "Modifica profilo" [level=2]
+  - img
+  - button "Modifica"
+  - text: Nome Mario Rossi
+  - button "Modifica Nome"
+  - text: Telefono +39 555 010 2030
+  - button "Copia"
+`;
+
+  const ARIA_PROFILE_EN = `- document:
+  - banner:
+    - heading "Edit profile" [level=2]
+  - text: Name John Doe
+  - text: Phone +1 555 123 4567
+`;
+
+  it("returns name + phone when profile pane is reachable (Italian locale)", async () => {
+    const page = makeWhoamiPage({ ariaMenu: ARIA_MENU_IT, ariaProfile: ARIA_PROFILE_IT });
+    const result = await commands.whoami(page);
+    assert.equal(result.name, "Mario Rossi");
+    assert.equal(result.phone, "+39 555 010 2030");
+  });
+
+  it("returns name + phone for English locale (no IT-specific labels)", async () => {
+    const ariaMenuEn = `- document:
+  - banner:
+    - heading "John Doe" [level=2]
+  - listbox:
+    - listitem:
+      - button "Profile Name, profile picture"
+  - banner:
+    - heading "WhatsApp" [level=2]
+`;
+    const page = makeWhoamiPage({ ariaMenu: ariaMenuEn, ariaProfile: ARIA_PROFILE_EN });
+    const result = await commands.whoami(page);
+    assert.equal(result.name, "John Doe");
+    assert.equal(result.phone, "+1 555 123 4567");
+  });
+
+  it("returns {name: null, phone: null} when profile button is not in DOM", async () => {
+    const page = makeWhoamiPage({ profileBtnExists: false, ariaMenu: "", ariaProfile: "" });
+    const result = await commands.whoami(page);
+    assert.equal(result.name, null);
+    assert.equal(result.phone, null);
+  });
+
+  it("filters out the 'WhatsApp' wordmark heading when picking the name", async () => {
+    // Edge case: WA is logged in but the user's display name field is empty,
+    // so the only level-2 heading on the menu is the "WhatsApp" wordmark.
+    // The function must NOT return "WhatsApp" as the user's name.
+    const ariaMenuOnlyWordmark = `- document:
+  - banner:
+    - banner:
+      - heading "WhatsApp" [level=2]
+`;
+    const page = makeWhoamiPage({ ariaMenu: ariaMenuOnlyWordmark, ariaProfile: "" });
+    const result = await commands.whoami(page);
+    assert.equal(result.name, null, "name should be null, not 'WhatsApp'");
+  });
+
+  it("JSON-stringifies cleanly to {name, phone}", async () => {
+    const page = makeWhoamiPage({ ariaMenu: ARIA_MENU_IT, ariaProfile: ARIA_PROFILE_IT });
+    const result = await commands.whoami(page);
+    const json = JSON.stringify(result);
+    const parsed = JSON.parse(json);
+    assert.deepEqual(Object.keys(parsed).sort(), ["name", "phone"]);
+  });
+});
+
+describe("CLI arg parsing: whoami", () => {
+  it("unknown command 'whoami' is wired (does not show 'Usage' help) when daemon is unreachable", async () => {
+    // Without a daemon the command will fail with an error — but it must NOT
+    // fall through to the `default` case that prints Usage. Easiest assertion:
+    // stderr should NOT contain the usage banner.
+    const { stderr, stdout } = await runCli("whoami");
+    assert.ok(
+      !stdout.includes("Usage: greentap <command>"),
+      `whoami should be a recognized command, got stdout: ${stdout}`,
+    );
+    // Either it succeeds, or it fails with an error — both are fine here.
+    // We just want to confirm the command is dispatched (not "unknown").
+    assert.ok(true, `stderr: ${stderr}`);
+  });
+});

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -345,7 +345,7 @@ describe("parseMessages — timestamps", () => {
     assert.equal(messages[0].timestamp, "2026-03-23 09:00");
   });
 
-  it("timestamp is empty string when no date separator seen", () => {
+  it("timestamp is null when no date separator seen", () => {
     const ariaNoSep = `- document:
   - banner:
     - button "Dettagli profilo":
@@ -357,7 +357,45 @@ describe("parseMessages — timestamps", () => {
     - textbox "Scrivi"`;
     const messages = parseMessages(ariaNoSep, { now: NOW });
     assert.ok(messages.length > 0, "should parse at least one message");
-    assert.equal(messages[0].timestamp, "", "timestamp should be empty with no date separator");
+    assert.equal(messages[0].timestamp, null, "timestamp should be null with no date separator");
+  });
+
+  it("timestamp is null when time is missing (graceful degradation)", () => {
+    // Defensive: a row with no recognizable HH:MM time AND no separator must
+    // not produce timestamp:"" — that's the empty-string footgun this test
+    // guards against.
+    const ariaNoTime = `- document:
+  - banner:
+    - button "Dettagli profilo":
+      - img
+  - row "Roberto Marini bare text no time":
+    - text: Roberto Marini hello world
+  - contentinfo:
+    - textbox "Scrivi"`;
+    const messages = parseMessages(ariaNoTime, { now: NOW });
+    for (const m of messages) {
+      assert.notEqual(m.timestamp, "", "timestamp must never be empty string, got: " + JSON.stringify(m));
+      assert.ok(m.timestamp === null || /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}$/.test(m.timestamp), `timestamp must be null or ISO-shaped, got: ${m.timestamp}`);
+    }
+  });
+
+  it("Ieri (yesterday) resolves deterministically against the passed `now` (post-midnight rollover scenario)", () => {
+    // Snapshot was read at 23:55 on 2026-03-31 ("Ieri" message timestamped 22:00).
+    // Parse runs at 00:05 on 2026-04-01 — but we pass the read-time `now`,
+    // so "Ieri" must still resolve to 2026-03-30, not 2026-03-31.
+    const readNow = new Date(2026, 2, 31, 23, 55);
+    const ariaYesterday = `- document:
+  - banner:
+    - button "Dettagli profilo":
+      - img
+  - text: Ieri
+  - row "Roberto Marini Ehi 22:00":
+    - text: Roberto Marini Ehi 22:00
+  - contentinfo:
+    - textbox "Scrivi"`;
+    const messages = parseMessages(ariaYesterday, { now: readNow, localeConfig: ITALIAN_TEST_LOCALE });
+    assert.ok(messages.length > 0, "should parse the Ieri message");
+    assert.equal(messages[0].timestamp, "2026-03-30 22:00", "Ieri must anchor to read-time `now`, not Date.now()");
   });
 
   it("produces timestamp without now when separator is absolute date (production path smoke)", () => {


### PR DESCRIPTION
## Summary

Two related quality items from a maintainer-reported usability issue (outbound identity + timestamp drift):

### 1. New `greentap whoami` command

Outbound messages have `sender: "You"` — agents and tooling can't tell WHICH WhatsApp account is the "You". Now there's:

\`\`\`bash
$ greentap whoami --json
{ "name": "<account display name>", "phone": "<account phone>" }
\`\`\`

Both fields can be `null` independently if WA's UI doesn't expose them on a given session — graceful degradation, never crashes. Pretty-print mode shows `Name:` / `Phone:` with `(not detected)` for nulls.

**Locale-agnostic identification:** the sidebar profile button is the only `<button>` whose child `<img>` has `whatsapp.net` in `src`. After clicking, the user's display name appears as the first `heading [level=2]`, and the phone is in the `Profilo`/`Profile` listitem. Probes confirmed `window.Store` / IndexedDB / localStorage do not expose name/phone in plaintext — click flow is the only viable read path.

### 2. Locale-stable timestamps

Reported bug: messages tagged `"Ieri"` (Yesterday) sometimes got translated to TODAY's date when locale resolution ran past midnight. Root cause: `parseDateSeparator` accepted a `now` parameter but callers in `lib/commands.js` never captured a stable read-time, so each parse used `new Date()` at parse time.

**Fix:** `read`, `scrollAndCollect`, `fetchImages` capture a single `readNow = new Date()` and pass it through `parseMessages`. `scrollAndCollect` uses one `readNow` across all iterations so a long scroll cannot split a chat across midnight.

### 3. Empty `timestamp` → `null`

`formatTimestamp` previously returned `""` when locale couldn't resolve a date. Now returns `null` (matches the `quoted_*` field convention from the parallel parser PR).

## Files

- `greentap.js` — wired `whoami` subcommand + help text
- `lib/commands.js` — added `whoami(page)`; passed stable `now=new Date()` into `parseMessages` from `read` / `scrollAndCollect` / `fetchImages`
- `lib/parser.js` — `formatTimestamp` returns `null` instead of `""`
- `test/cli.test.js` — 5 new whoami unit tests + 1 CLI dispatch test (synthetic numbers only)
- `test/parser.test.js` — empty-timestamp test asserts `null`; new defensive null-shape test + post-midnight rollover test

## Tests

`npm test`: **147/147 pass**.

## Live validation (sandbox)

- `whoami --json`: returns `{ name: "<present>", phone: "<present>" }` — both fields populated. (Real values not logged — PII discipline.)
- `read --json` on sandbox: 20 messages, **0 empty `timestamp`** (10 valid ISO strings + 10 explicit `null`).

## Trade-off flagged

`whoami` requires a click on the profile button to read the phone. The function leaves the page in the profile pane on completion, then escapes back. R5 navigateToChat fast-path handles subsequent commands cleanly.

## Source

Q3 of v0.4.0 quality batch. Other concurrent PRs: send newline handling, parser robustness.

## Test plan

- [x] `npm test` green (147/147)
- [x] Live `whoami` returns populated name + phone
- [x] Live `read` returns no empty timestamps
- [x] PII grep clean (synthetic numbers only, no task tracker IDs, no real names)
- [ ] Maintainer independent review