### PR TITLE
chore: release prep v0.4.0 — SKILL coherence + PII rules + ROADMAP + coherence checker

### DIFF
--- a/.claude/skills/greentap/SKILL.md
+++ b/.claude/skills/greentap/SKILL.md
@@ -6,14 +6,18 @@ description: |
   - Check unread messages or chat list
   - Read messages from a specific chat
   - Search for a contact or group
-  - Send a message to a contact or group
+  - Send a message (single- or multi-line) to a contact or group
   - Draft a message for review before sending
   - Read poll results from a chat
+  - Download images from a chat
+  - Recover full URLs from link previews
+  - Identify which WhatsApp account is currently in use
   Triggers: "whatsapp", "check messages", "read chat", "send message to",
-  "unread messages", "message from", "greentap", "poll results", "sondaggio"
+  "unread messages", "message from", "greentap", "poll results", "sondaggio",
+  "download image", "fetch image", "whoami", "who am i", "link preview"
 license: MIT
-compatibility: "Requires Node.js 18+, Google Chrome (system install)"
-allowed-tools: Bash
+compatibility: "Requires Node.js 18+, bundled Playwright Chromium (auto-installed)"
+allowed-tools: Bash, Read
 ---
 
 # greentap — WhatsApp Web CLI via Playwright
@@ -23,12 +27,15 @@ Uses a background browser daemon for fast (~500ms) command execution.
 
 ## Prerequisites
 
-- Node.js (v18+), Google Chrome (system install)
+- Node.js (v18+); bundled Chromium auto-installed via `npx playwright install chromium`
 - First run: `node greentap.js login` to scan QR code
 
 ## Commands
 
 ```bash
+# Identity of the currently logged-in WA account
+node greentap.js whoami --json
+
 # List visible chats with last message and unread count
 node greentap.js chats --json
 
@@ -36,6 +43,8 @@ node greentap.js chats --json
 node greentap.js unread --json
 
 # Read messages from a chat (substring match on name)
+# Each message includes: sender, time, text, body, quoted_sender, quoted_text,
+# links[], kind, imageId (when image), is_self, timestamp
 node greentap.js read "contact or group name" --json
 
 # Read full chat history (scrolls up, deduplicates)
@@ -49,11 +58,19 @@ node greentap.js send "contact or group name" --index 2 "message text"
 node greentap.js search "query" --json
 
 # Send a message (finds chat by name, types and sends)
-node greentap.js send "contact or group name" "message text"
+# Multi-line messages: use real \n in the string — they are sent as one bubble
+node greentap.js send "contact or group name" "line one
+line two"
 
 # Read poll results from a chat (most recent poll, with vote counts per option)
 node greentap.js poll-results "contact or group name" --json
 node greentap.js poll-results "contact or group name" --index 2 --json
+
+# Download recently-visible images from a chat to ~/.greentap/downloads/<chat-slug>/
+node greentap.js fetch-images "contact or group name" --limit 3 --json
+
+# E2E roundtrip verification against the dedicated greentap-sandbox group
+GREENTAP_E2E=1 node greentap.js e2e
 
 # Daemon management
 node greentap.js status
@@ -62,24 +79,62 @@ node greentap.js daemon stop
 
 ## Important behavior
 
-- **Daemon**: first command auto-launches a background Chrome instance (port 19222), shuts down after 15min idle
-- **read** shows messages visible in the viewport by default; use `--scroll` for full history
-- **read** marks messages as read in WhatsApp (cannot be prevented)
-- **send** verifies correct chat opened and message delivered
-- **poll-results** navigates to the chat and reads the most recent WhatsApp native poll (question + options + vote counts)
-- If multiple chats share the same name, commands error with a numbered list — re-run with `--index N` to pick one
-- Chat matching is case-insensitive substring
-- Locale-agnostic: works with any WhatsApp UI language
-- Own messages have `sender: "You"` in JSON output
-- Messages include `timestamp: "YYYY-MM-DD HH:MM"` (full date+time); empty string if chat shows no date separators
+- **Daemon**: first command auto-launches a background Chromium instance (port 19222), shuts down after 15min idle. Bundled Chromium with `HeadlessChrome` UA stripped so WhatsApp Web accepts it.
+- **read** shows messages visible in the viewport by default; use `--scroll` for full history.
+- **read** marks messages as read in WhatsApp (cannot be prevented).
+- **send** verifies correct chat opened and message delivered. Multi-line strings (with `\n`) become one WA bubble (uses Shift+Enter internally).
+- **poll-results** navigates and reads the most recent WhatsApp native poll.
+- **fetch-images** writes JPEG/PNG/WebP files to `~/.greentap/downloads/<chat-slug>/<imageId>.<ext>` with mode 0o600. Returns absolute paths so the agent can `Read` them for multimodal understanding.
+- **whoami** returns `{ name, phone }` for the currently logged-in account. Either field can be `null` if WhatsApp Web doesn't expose it on this session.
+- **e2e** runs four ordered stages (preflight, text, image, link) against the sandbox group `greentap-sandbox` (must exist; only the maintainer is a member). Output is structural JSON — no message content logged.
+- If multiple chats share the same name, commands error with a numbered list — re-run with `--index N` to pick one.
+- Chat matching is case-insensitive substring.
+- Locale-agnostic: works with any WhatsApp UI language.
+
+## Read output schema
+
+Each message in `read --json` carries these fields (additive over time — older clients can ignore unknown fields):
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `sender` | string | Always populated. `"You"` for outbound; `"(unknown)"` if unattributable. Never empty string. |
+| `time` | string | `"HH:MM"` from the row label. |
+| `timestamp` | string \| null | `"YYYY-MM-DDTHH:MM"` ISO when WA shows a date separator; `null` otherwise. Stable across midnight (uses snapshot read-time, not parse-time). |
+| `text` | string | Full visible text, including any quoted-reply bleed (backward compat). |
+| `body` | string \| null | New: just the user's new text, with the quoted block removed. Equal to `text` when no quote. |
+| `quoted_sender` | string \| null | New: author of the quoted message when this is a reply-with-quote. |
+| `quoted_text` | string \| null | New: text of the quoted message. |
+| `links` | `[{href, text}]` | http(s) URLs recovered from the DOM (handles WhatsApp's truncated previews). |
+| `kind` | string | `"text"` or `"image"` (more kinds may appear in future versions). |
+| `imageId` | string | Only on `kind: "image"`. Stable across reads of the same DOM. Use with `fetch-images` to materialize. |
+| `is_self` | boolean | True for outbound messages. Pair with `whoami` to identify which account "self" is. |
+
+## Multimodal flow for images
+
+```
+$ node greentap.js fetch-images "Famiglia Rossi" --limit 3 --json
+[
+  { "imageId": "a7f3c211", "path": "/Users/<you>/.greentap/downloads/famiglia-rossi/a7f3c211.jpg",
+    "sender": "Elena Conti", "time": "14:22", "mimeType": "image/jpeg" }
+]
+```
+
+After receiving the path: open with the Read tool — the image is handed to Claude as multimodal input. Describe, OCR, or reason about it directly. Delete the file when no longer needed (cache is not auto-pruned).
+
+Limitations:
+- Thumbnail resolution only (full-resolution viewer download is a future enhancement)
+- Does not fetch images outside the currently-rendered DOM — scroll or re-read first
 
 ## Guidelines for the agent
 
-- Use `--json` for parsing, plain text when showing to the user
-- **NEVER send a message without explicit user confirmation**
-- When drafting messages, match the language the user typically uses with that contact
-- If asked to "check messages", start with `greentap unread --json`
-- If a chat isn't found, try `greentap search` with a shorter query
-- If asked about poll results or a vote, use `greentap poll-results`
-- Keep tool calls minimal — one `unread` or `read` call is usually enough
-- First command auto-starts daemon (~6s cold start), subsequent ones are ~500ms
+- Use `--json` for parsing, plain text when showing to the user.
+- **NEVER send a message without explicit user confirmation.**
+- When drafting messages, match the language the user typically uses with that contact.
+- If asked to "check messages", start with `greentap unread --json`.
+- If a chat isn't found, try `greentap search` with a shorter query.
+- If asked about poll results or a vote, use `greentap poll-results`.
+- For image content questions, use `fetch-images` then `Read` the path.
+- For full URLs (link previews), use `read --json` and inspect the `links[]` array — the visible `text` is often a truncated preview.
+- For "who am I" / outbound identification: `whoami`.
+- Keep tool calls minimal — one `unread` or `read` call is usually enough.
+- First command auto-starts daemon (~6s cold start), subsequent ones are ~500ms.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,17 +25,26 @@ Full rules: CONTRIBUTING.md → "Merge approval protocol" and
 ## Test plan
 
 - [ ] `npm test` passes locally
-- [ ] PII check: no real names, numbers, or chat content in new fixtures
 - [ ] **If the diff touches `lib/commands.js`, `lib/parser.js`, `lib/daemon.js`, `lib/client.js`, `lib/locale.js`, or `test/fixtures/**`:**
   - [ ] `GREENTAP_E2E=1 node greentap.js e2e` passes locally (exit 0)
   - [ ] The stage that exercises THIS PR's feature actually RAN — it was NOT skipped (confirm by reading the stage list in stdout)
   - [ ] If this PR adds image download: the downloaded image was Read()-verified multimodally and the text `GREENTAP-E2E` is legible in the pixels
   - [ ] If e2e cannot run for any reason (daemon blocked, sandbox issue, preflight bug): this PR does NOT merge until the blocker is fixed
 
+## PII pass — MANDATORY before merge
+
+PII check applies to **every** PR (including doc-only). See `CONTRIBUTING.md` § "PII patterns" for the full list.
+
+- [ ] Diff content grepped — no maintainer name, no task-tracker URLs, no task IDs, no real phone numbers, no `/Users/<maintainer-username>/` paths, no real chat content
+- [ ] **Commit messages** grepped — same patterns as above. Commit messages get baked into the squash-merge body and are public forever.
+- [ ] **PR title and body** grepped — same patterns. PR bodies are also public on GitHub permanently.
+- [ ] If a PR adds a new `lib/commands.js` command: the command + its JSON output schema is documented in `.claude/skills/greentap/SKILL.md` (skill-coherence rule)
+
 ## Review
 
 - [ ] `/review-code` run locally; blockers fixed
 - [ ] `/review-security` run locally; blockers fixed
+- [ ] If new public-API surface added: skill-coherence subagent ran (see `docs/skill-coherence-checker.md`) and confirmed `.claude/skills/greentap/SKILL.md` covers it
 
 ## Merge authorization
 

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ skills/
 !.claude/skills/
 skills-lock.json
 scratch/
+node_modules

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,13 +8,63 @@ scope.
 
 ## Ground rules
 
-- **No PII.** Fixtures and tests must use fake personas
-  (e.g. Roberto Marini, Elena Conti, Famiglia Rossi). Never commit
-  real names, phone numbers, chat content, or any identifier that
-  could be traced to a real person. CI (when added) will grep.
+- **No PII.** See the explicit pattern list below. Fixtures and tests must
+  use fake personas (e.g. Roberto Marini, Elena Conti, Famiglia Rossi).
 - **Locale-agnostic selectors.** Don't hardcode WhatsApp UI strings.
   See `CLAUDE.md` for the three-tier selector strategy.
 - **TDD.** Write the failing test first; make it pass.
+
+## PII patterns — mandatory pre-merge grep
+
+Every PR — **including doc-only PRs** — MUST pass a PII grep before
+push and again before merge. Run this against the diff and against
+each commit message:
+
+```bash
+# Run with the real tokens substituted in your local shell —
+# do NOT put the real tokens in this file or in any committed shell
+# script. The patterns below are placeholders.
+git log --format='%H%n%s%n%b' origin/main..HEAD | \
+  grep -iE '(<maintainer-first-name>|<maintainer-last-name>|<task-tracker-domain>|/Users/<maintainer-username>|@<maintainer-email-domain>|<your-real-phone-prefix>)'
+```
+
+Forbidden tokens, by category:
+
+- **Maintainer's name** — first name, last name, nickname. Even
+  standalone in commit subjects or PR bodies.
+- **Maintainer's email** — including any `@<personal-domain>` fragment.
+- **Absolute filesystem paths** containing the maintainer's username
+  (`/Users/<name>/...`).
+- **Task-tracker URLs and IDs** — task tracker app URLs, raw task IDs (the
+  short opaque alphanumeric strings these systems use), Linear/Jira/etc
+  URLs with private workspace tokens.
+- **Real phone numbers** — anything matching `+\d{10,15}` that's not in
+  the synthetic-prefix allowlist (`+39 555 ...` / `+1 555 ...` are
+  reserved for documentation, not assigned).
+- **Real chat content** — quotes from real WhatsApp conversations,
+  group names that aren't the established fake personas, real contact
+  references.
+
+Allowed exceptions:
+
+- Author / committer metadata (`%an`/`%ae`) — can show the maintainer's
+  real identity. Considered out-of-scope for the content rules above
+  because GitHub fingerprints commits this way regardless.
+- Fake personas: Roberto Marini, Daniele Bottazzini, Elena Conti,
+  Famiglia Rossi, Lavinia Vitale, Estevan Tioni, Flavia, Amanda,
+  Mattia, "Ferragosto" (Italian holiday).
+- Synthetic phone numbers: `+39 02 0000 00000`, `+39 555 010 2030`,
+  `+1 555 123 4567`. Document any new synthetic number in this list
+  before using it.
+
+If a leak is found post-merge in commits NOT yet inside a tagged
+release: rewrite history with `git filter-branch --msg-filter` (or
+`git filter-repo --replace-message`), then force-push under temporary
+relaxation of branch protection. Restore protection immediately after.
+
+If a leak is found in commits ALREADY inside a tagged release: do not
+rewrite. Document the leak in `docs/known-leaks.md` with the SHA and
+content category, and apply prevention to future PRs.
 
 ## Merge approval protocol
 
@@ -130,6 +180,96 @@ does not merge.
    function body.
 3. The `test/e2e-guard.test.js` enforcement test will verify the
    new command rejects non-sandbox chats.
+4. Document the command + its JSON shape in
+   `.claude/skills/greentap/SKILL.md`. Run the skill-coherence checker
+   (`docs/skill-coherence-checker.md`) — verdict MUST be `COHERENT`
+   before tagging the next release.
+
+## Release procedure
+
+Releases follow semver (`v0.<minor>.<patch>`). All releases are manually
+tagged from `main`. There is no CHANGELOG file — release notes live on
+GitHub.
+
+### Pre-tag checklist (mandatory)
+
+Before running `git tag`, **every** item must be green:
+
+1. **All open PRs intended for this release are merged.** Verify with
+   `gh pr list --state open`. Defer anything that didn't make it; do
+   not block the release on a half-finished PR.
+2. **`main` is clean.** `git status` clean, `git log` shows nothing
+   surprising since the previous tag.
+3. **`npm test` on `main` HEAD is green.**
+4. **`GREENTAP_E2E=1 node greentap.js e2e` on `main` HEAD is green.**
+   This is a NEW pre-tag requirement: per-PR e2e runs catch each
+   change in isolation, but the cumulative state of `main` must also
+   pass before a tag. If a stage fails, the release is blocked until
+   fixed (which itself may be a new PR).
+5. **Skill coherence checker** (`docs/skill-coherence-checker.md`)
+   returns `verdict: "COHERENT"`. New commands or new JSON fields
+   added since the previous tag MUST be in `SKILL.md`.
+6. **PII grep on every commit message since the previous tag is
+   clean** — see § "PII patterns" above. Forbidden tokens must NOT
+   appear in any commit message, PR title, or PR body.
+7. **PII grep on the diff `<prev-tag>..HEAD` is clean.** Tracked
+   files only — `git ls-files` × `git show <SHA>:<file>`. Same
+   forbidden-token list.
+
+### Tag + release
+
+```bash
+# Replace 0.x.y with the actual version
+git tag v0.x.y
+git push origin v0.x.y
+
+gh release create v0.x.y \
+  --title "v0.x.y — short title" \
+  --notes "$(cat <<'EOF'
+## Highlights
+
+- Bullet of the headline feature
+- Bullet of the second-most-important thing
+
+## All changes
+
+(Generated from \`git log <prev-tag>..v0.x.y --oneline\`. Trim trivial
+commits, group by category if useful.)
+
+## Upgrade notes
+
+(Anything users have to do manually — re-login, install a new
+binary, contract changes, etc. If nothing, write "None.")
+
+## Known limits
+
+(Carry-over warnings from CONTRIBUTING / SKILL.md / ROADMAP.)
+EOF
+)"
+```
+
+### Version bump rules
+
+- **Patch (`v0.x.y` → `v0.x.(y+1)`):** bug fixes only, no new
+  features, no contract changes.
+- **Minor (`v0.x.y` → `v0.(x+1).0`):** new commands, new fields in
+  read output (additive), new flags. Backward-compatible.
+- **Major (`0.x.y` → `1.0.0`):** breaking contract changes (e.g.
+  removing a field, renaming a command, changing JSON shape in a way
+  consumers can't ignore). greentap is currently `0.x` — major bump
+  is reserved for a stability commitment.
+
+If a release also rewrote git history on `main` for PII reasons,
+note that in the upgrade notes (any consumer with an old clone needs
+to re-clone or `git fetch + reset --hard origin/main`).
+
+### Post-tag
+
+- Verify the GitHub release page renders correctly
+- Verify `npx skills add psacc/greentap` picks up the new version
+  (skills.sh indexing may take a few minutes)
+- Update the project memory with anything notable (next session's
+  agent benefits from a tight summary of what shipped)
 
 ## PR checklist
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ npm install
 npx playwright install chromium   # if not run automatically by your setup
 ```
 
-> **v0.3.2+ note:** greentap now uses Playwright's bundled Chromium (was system Chrome). If you upgraded from v0.3.1 or earlier, you will need to re-scan the QR code via `greentap login` — browser profile data is not portable between Chrome and Chromium.
+> **v0.4.0+ note:** greentap uses Playwright's bundled Chromium (was system Chrome in v0.3.x). If you upgraded from v0.3.1 or earlier, you will need to re-scan the QR code via `node greentap.js login` — browser profile data is not portable between Chrome and Chromium.
 
 First run — scan the QR code to link your WhatsApp account:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,9 +1,9 @@
 ## Strategic context
-Priority: medium — stable and released, in maintenance/exploration mode
-Current phase: Phase 7 — multi-agent concurrency (explore)
+Priority: medium — stable, agent-autonomy + media shipped in v0.4.0
+Current phase: Phase 9 — quality polish (sticker visibility, performance, sender inheritance hardening) — target v0.5.0
 Blocks: nothing
 Blocked by: nothing
-Last updated: 2026-04-02
+Last updated: 2026-04-25
 → Full strategic context: psacc/docs/ROADMAP.md
 
 ---
@@ -37,10 +37,11 @@ Migrating to Playwright on WhatsApp Web, following the same pattern as hey-cli.
 | Account ban (ToS violation) | Medium | Low volume, human-like delays, personal account |
 | Session expires (14-day inactivity) | Low | Keep sessions active, `greentap login` to re-auth |
 | Aria labels are locale-dependent | Low | Mitigated: structural ARIA selectors + runtime locale detection (Phase 6) |
-| WhatsApp rejects bundled Chromium | Pending verification (2026-04-22) | Switched to bundled Chromium in v0.3.2 for CDP port isolation. If WA rejects, revert `channel: "chrome"` and open issue for user-agent spoofing. |
-| Aria tree restructuring (WA updates) | Medium | Two row formats already handled; parser may need updates |
+| WhatsApp rejects bundled Chromium | Resolved (2026-04-25) | Bundled Chromium adopted; daemon strips `HeadlessChrome` from UA via CDP `Network.setUserAgentOverride`, WA accepts the session. |
+| Aria tree restructuring (WA updates) | Medium | Two row formats already handled; parser may need updates. E2E harness catches breakage early. |
+| Sticker vs photo input confusion | Mitigated (2026-04-25) | E2E `sendFixtureImage` uses Allega → Foto e video flow keyed on `ic-filter-filled` icon; never touches the sticker input. |
 
-**Current: Phase 7 (explore)**
+**Current: Phase 9 (quality polish, v0.5.0 target)**
 
 ## Phases
 
@@ -112,14 +113,38 @@ Migrating to Playwright on WhatsApp Web, following the same pattern as hey-cli.
 - [x] `--index N` flag — disambiguates multiple chats with the same name (v0.3.0)
 - [x] Timestamp enrichment from date separators — adds `timestamp` to message JSON (v0.3.1)
 
-### Phase 7 — Multi-agent Concurrency (explore)
+### Phase 7 — Multi-agent Concurrency (deferred)
 - [ ] Spike: can multiple agents use greentap concurrently without interfering?
 - [ ] Options: tab-per-agent, port-per-agent, locking, or queuing
 - [ ] Assess: is this a real need or premature optimization?
 
-### Phase 8 — Media (post-release)
-- [ ] Send/receive images
-- [ ] Receive voice messages (download audio from chat)
-- [ ] Transcribe voice messages (Whisper or equivalent)
-- [ ] Surface transcription in `read` output
+Status: deferred. Single-agent usage works. Re-open if multiple parallel agents become a real need.
+
+### Phase 8 — Media + Agent Autonomy ✓ (shipped v0.4.0)
+
+- [x] Daemon hardening — port file pre-launch (#15), bundled Chromium with UA strip (#15+#21)
+- [x] `navigateToChat` robustness — wait-for-grid (#16), `--index` in search fallback, fast-path no-op when chat already open (#24)
+- [x] `read --json` link recovery — `links: [{href, text}]` per message via DOM walk; greedy monotone merge handles parser/DOM length drift and URL-only messages (#17 + #22)
+- [x] `fetch-images <chat>` command — in-DOM blob download to `~/.greentap/downloads/<chat-slug>/` (#18 + #23)
+- [x] E2E harness — `greentap e2e` against `greentap-sandbox` group, four stages roundtripped end-to-end with multimodal verification (#19 + #25)
+- [x] Iron-clad merge + e2e rules — per-PR maintainer approval, feature-stage-must-not-be-skipped (#20)
+- [x] `send` newline handling — `\n` becomes Shift+Enter, multi-line messages stay in one bubble (#26)
+- [x] Parser robustness — `sender` always populated, additive `quoted_sender` / `quoted_text` / `body` fields, orphan-row recovery (#27)
+- [x] `whoami` command + locale-stable timestamps + `null`-instead-of-empty (#28)
+
+### Phase 9 — Quality polish (planned, v0.5.0 target)
+
+- [ ] **Sticker visibility** — parser `kind: "sticker"` + `fetchStickers` download. Reuses fetchImages mechanics with a different DOM marker. Tracked in task tracker.
+- [ ] **Sender-inheritance hardening** — current orphan-row recovery blindly inherits previous-row sender. Tighten to require a "same-author" hint (e.g. `msg-dblcheck` for own, structural cue) and prefer `(unknown)` when ambiguous. Tracked in task tracker.
+- [ ] **Performance hygiene** — concrete proposals reviewed by 3 independent agents, accepted only if no functionality loss. Likely targets: replace hardcoded `setTimeout` waits with element-based `waitFor`, reduce review-agent prompt size for diffs <30 LOC, cheaper overlay-dismiss alternative to `page.reload()` between e2e stages.
+
+### Phase 10 — Voice + documents (deferred, no spike yet)
+
+- [ ] Voice messages — download audio + transcribe (Whisper or equivalent)
+- [ ] Documents / generic file download — same blob pattern as images, MIME detection trickier
 - [ ] Feasibility spike: can audio URLs be extracted from aria snapshot or DOM?
+
+### Phase 11 — Skill coherence automation (planned)
+
+- [ ] Pre-release subagent that compares `lib/commands.js` exports + new fields in parser output against `.claude/skills/greentap/SKILL.md`. Fails CI if a public-API surface is undocumented.
+- [ ] Currently a manual checklist item in `.github/pull_request_template.md`; promote to automated check before tagging v0.5.0.

--- a/docs/skill-coherence-checker.md
+++ b/docs/skill-coherence-checker.md
@@ -1,0 +1,97 @@
+# Skill Coherence Checker
+
+A subagent prompt template that audits `.claude/skills/greentap/SKILL.md` against the actual public surface of the codebase. Run before every release tag, and as part of the PR checklist for any change that adds a new command or new JSON field.
+
+## When to run
+
+- Before tagging a release (`v0.x.0`) — mandatory
+- For any PR that adds a new exported command in `lib/commands.js` (the `greentap.js` dispatcher), a new `--flag` to an existing command, or a new field on `read --json` output — recommended
+- Manually: `/coherence-check` (alias if the maintainer wires it)
+
+## What it checks
+
+The subagent compares three sources of truth:
+
+1. **`greentap.js`** — the CLI dispatcher's `case "<name>":` blocks define the user-visible command list
+2. **`lib/commands.js`** — exported functions define the underlying API; their parameter names define `--flag` names; their return shapes define the JSON output schema
+3. **`lib/parser.js`** — `parseMessages` return shape defines per-message JSON fields
+
+Against:
+
+4. **`.claude/skills/greentap/SKILL.md`** — the agent-facing documentation that downstream tooling reads to decide what to call
+
+## Coherence rules
+
+A SKILL.md is coherent when:
+
+- Every `case "<name>"` in `greentap.js` is documented in SKILL.md's `Commands` section, with at minimum a one-line description and the typical `--json` invocation
+- Every `--flag` accepted by a command is mentioned in its example or behavior block
+- Every field in the message JSON schema (parser output) is in the schema table — including `null`-able fields and their semantics
+- New commands flagged with hard-stop semantics (e.g. requires `GREENTAP_E2E=1`) call that out explicitly
+
+## Subagent prompt template
+
+```
+You are auditing greentap's SKILL.md for coherence with the codebase.
+
+## Step 1 — Inventory the codebase
+
+Read these files in their entirety:
+- `greentap.js` — extract every `case "<name>":` and its dispatched function call
+- `lib/commands.js` — extract every `export async function <name>` / `export function <name>` plus their parameter names and JSDoc return shapes
+- `lib/parser.js` — find `parseMessages` and identify every distinct field it can emit on a message object (including null-able / additive fields)
+
+Produce three lists:
+- COMMANDS = [name, dispatcher_args, exported_fn]
+- FLAGS = [(command, flag_name)]
+- MESSAGE_FIELDS = [(field, type, semantics_in_one_line)]
+
+## Step 2 — Read SKILL.md
+
+`.claude/skills/greentap/SKILL.md` — extract:
+- DOCUMENTED_COMMANDS = the names appearing in the Commands section
+- DOCUMENTED_FLAGS = the flags shown in any example or the schema table
+- DOCUMENTED_FIELDS = the rows of the "Read output schema" table (or equivalent)
+
+## Step 3 — Diff
+
+- Commands missing from SKILL.md = COMMANDS − DOCUMENTED_COMMANDS
+- Commands in SKILL.md that don't exist in code = DOCUMENTED_COMMANDS − COMMANDS
+- Flags missing = FLAGS − DOCUMENTED_FLAGS
+- Fields missing = MESSAGE_FIELDS − DOCUMENTED_FIELDS
+- Fields in SKILL.md that no longer exist = DOCUMENTED_FIELDS − MESSAGE_FIELDS
+
+## Step 4 — Report
+
+Output a JSON-shaped report:
+
+{
+  "verdict": "COHERENT" | "GAPS",
+  "missing_commands": [...],
+  "stale_commands": [...],
+  "missing_flags": [...],
+  "missing_fields": [...],
+  "stale_fields": [...],
+  "recommended_diff": "a unified diff against SKILL.md that closes the gaps (or empty if COHERENT)"
+}
+
+Do NOT modify any files. Do NOT propose code changes outside SKILL.md. Do not infer features from SKILL.md alone — code is the source of truth.
+```
+
+## Integration
+
+- `.github/pull_request_template.md` includes a checkbox referencing this doc
+- `CONTRIBUTING.md` § "Adding a new chat-targeting command" cross-references this checker
+- Phase 11 (ROADMAP) plans to promote this from a checklist item to a CI step before tagging v0.5.0
+
+## False positives
+
+The diff approach is structural. Acceptable false positives:
+
+- Internal helpers prefixed `_` or starting with lowercase that are not part of the command surface (the CLI dispatcher is the source of truth — only commands listed in `greentap.js` are user-facing)
+- Test-only fields (e.g. ones that show up in fixtures but never in real output) — flag as advisory, not gap
+- Fields that are intentionally deprecated but still emitted — should be kept in SKILL.md with a "(deprecated)" marker
+
+## Cost
+
+A single subagent invocation, ~3 minutes wall clock, ~10K tokens. Cheap enough to run every release. CI integration would make it free per-PR.


### PR DESCRIPTION
## Summary

Final docs/process polish before tagging **v0.4.0**. No code changes — 7 files updated:

1. **`.claude/skills/greentap/SKILL.md`** — every command shipped in v0.4.0 documented (`whoami`, `fetch-images`, `e2e`); new "Read output schema" table covers `links[]`, `quoted_sender`, `quoted_text`, `body`, `kind`, `imageId`, `is_self`, nullable `timestamp`; new "Multimodal flow for images" section.
2. **`CONTRIBUTING.md`** — explicit PII pattern list; mandatory PII grep before push and before merge applies to ALL PRs including doc-only; documents the rewrite-history-only-for-untagged-commits remediation rule. **NEW: explicit "Release procedure" section** with pre-tag checklist (all PRs merged, `npm test` green, e2e green on main HEAD, skill coherence pass, PII grep) + tag/release steps + version bump rules + post-tag verification.
3. **`.github/pull_request_template.md`** — new "PII pass — MANDATORY before merge" section (diff / commit messages / PR body); coherence-check item for any PR adding a public-API surface.
4. **`README.md`** — version note bumped from `v0.3.2+` placeholder to actual `v0.4.0+`.
5. **`ROADMAP.md`** — Phase 8 marked shipped with full PR cross-references; Phase 9 (quality polish, v0.5.0) lists sticker visibility, sender-inheritance hardening, performance hygiene; Phase 10 (voice + documents) deferred; Phase 11 (skill coherence automation) added.
6. **`docs/skill-coherence-checker.md`** (new) — subagent prompt template that audits SKILL.md against `greentap.js` + `lib/commands.js` + `lib/parser.js`. Manual today; CI step before tagging v0.5.0.
7. Removed an accidental `node_modules` symlink from a previous commit.

## What was missing before this PR (now addressed)

- **Release process was undocumented in public docs.** Only an internal recipe in CLAUDE.md. Now CONTRIBUTING.md has the full pre-tag checklist + tag/release steps.
- **No "run e2e on main HEAD before tag" mandate.** Per-PR e2e covers each change in isolation, but the cumulative state of `main` was an emergent property. Now explicit pre-tag step.
- **Local installation note pointed to v0.3.2+** which was a placeholder. Updated to v0.4.0+.

## Tests

`npm test`: untouched (no code in this PR). Doc-only.

## E2E exemption

Doc-only PR — `lib/**` not touched. Per `CONTRIBUTING.md` § "E2E is mandatory", e2e is not required for this PR.

## PII pass

- [x] Diff grepped — no maintainer name, no task-tracker URLs, no task IDs, no real phone numbers, no `/Users/<maintainer-username>/` paths, no real chat content
- [x] Commit message grepped — clean
- [x] PR body grepped — clean

## What this unlocks

After merge, the v0.4.0 tag procedure is the FIRST release governed by the new explicit process. Pre-tag checklist runs against `main` HEAD, then tag + release.

## Test plan

- [x] `npm test` green (no code change, but verified)
- [x] PII grep clean
- [ ] Maintainer review

After merge: ping for v0.4.0 release approval (separate, requires running the new pre-tag checklist).