### PR TITLE
release: v0.5.0 — reliability fixes + nav/fetch features

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "greentap",
-  "version": "0.3.1",
+  "version": "0.5.0",
   "description": "CLI driver for WhatsApp Web via Playwright",
   "main": "greentap.js",
   "bin": {


### PR DESCRIPTION
## Summary

Minor release after v0.4.0. Two new features (fetch-images `--scroll`, navigate partial-match hints) plus three reliability fixes in the parser/read pipeline. Also catches up the stale `package.json` (was 0.3.1 vs git tag v0.4.0).

Per CONTRIBUTING.md semver: 2 feat commits → minor bump (v0.4.0 → v0.5.0). Skipping v0.4.1 entirely.

## Release notes

### Bug fixes

- **parser**: strip `~` prefix from sender names + detect button-wrapped quote-cards (resolves attribution bug on quote-reply chains)
- **parser**: strip `Forse`/`Maybe` probable-contact-match prefix from sender (cleaner UX when WhatsApp can't unambiguously match a phone number to a contact)
- **read**: retry once after 800ms when first parse returns no messages (default UX is now "see currently visible messages" instead of `[]`)

### Features

- **fetch-images**: new `--scroll` flag + stderr diagnostics distinguishing "scroll needed" from "WhatsApp revoked thumbnails"
- **navigate**: suggest partial matches when chat name has no exact match (replaces silent fallback with helpful hint)

### Docs

- SKILL.md aligned with codebase per coherence checker (#30) — included in this release if not already in v0.4.0 tag

### Tests

- +565 lines / -44 across 4 new test files
- Regression coverage for quote-reply attribution case (anonymized fixture)

### Notes

- **Version jump 0.3.1 → 0.5.0** catches up the stale `package.json` (was 0.3.1 vs git tag v0.4.0); follows CONTRIBUTING.md semver: 2 feats → minor (v0.5.0).
- **Public commit history was rewritten on 2026-04-27** to scrub PII (real-person-names + real phone numbers) accidentally introduced in test fixtures. Anyone with a clone from 2026-04-27 12:51 to 14:12 should `git fetch && git reset --hard origin/main` to align.

## Test plan

- [ ] `npm test` green on this branch
- [ ] `GREENTAP_E2E=1 node greentap.js e2e` green on this branch (link + image stages active, not skipped)
- [ ] PII grep on `v0.4.0..HEAD` clean (already verified pre-PR — only synthetic `+39 555 0000 000` and author metadata)
- [ ] Skill coherence checker returns `COHERENT`
- [ ] Maintainer review

After merge, maintainer will tag `v0.5.0` and create the GitHub release.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>