### PR TITLE
fix(read): scroll to bottom before snapshot to capture latest messages

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -307,6 +307,41 @@ async function findLoadMoreButton(page) {
   });
 }
 
+/**
+ * Force the message panel to scroll to the absolute bottom and wait for
+ * WhatsApp Web's virtualized list to materialize the latest rows in the DOM.
+ *
+ * Why this exists: when navigateToChat opens an active chat, WA may land the
+ * viewport at the unread divider rather than the absolute bottom — leaving
+ * recent messages un-rendered in the DOM. The chat-list panel's preview
+ * (read from the sidebar grid) shows the actual latest message, but the
+ * conversation pane's ariaSnapshot reflects only the materialized window.
+ * Without forcing a scroll-to-bottom + settle, parseMessages silently drops
+ * messages whose rows haven't been mounted yet (the Ponte 1-5-26 bug,
+ * 2026-05-10).
+ *
+ * Pins to bottom twice with a settle in between: the first scroll triggers
+ * row materialization, which can shift the layout and bump scrollTop; the
+ * second pin re-anchors at the new scrollHeight.
+ *
+ * Returns true on success, false on graceful degradation (scroll container
+ * not found — caller falls back to plain snapshot).
+ */
+export async function ensureScrolledToBottom(page, settleMs = 700) {
+  const found = await findScrollContainer(page);
+  if (!found) return false;
+  await page.evaluate(() => {
+    const el = document.querySelector('[data-greentap-scroll="1"]');
+    if (el) el.scrollTop = el.scrollHeight;
+  });
+  await new Promise((r) => setTimeout(r, settleMs));
+  await page.evaluate(() => {
+    const el = document.querySelector('[data-greentap-scroll="1"]');
+    if (el) el.scrollTop = el.scrollHeight;
+  });
+  return true;
+}
+
 async function scrollAndCollect(page, localeConfig) {
   const found = await findScrollContainer(page);
   if (!found) throw new Error("Could not find scrollable message container");
@@ -368,19 +403,28 @@ async function scrollAndCollect(page, localeConfig) {
     console.error("WARNING: Max scroll iterations reached. Returning partial results.");
   }
 
-  // Scroll back to bottom so subsequent reads see latest messages
-  await page.evaluate(() => {
-    const el = document.querySelector('[data-greentap-scroll="1"]');
-    if (el) el.scrollTop = el.scrollHeight;
-  });
+  // Scroll back to bottom so subsequent reads see latest messages, then take
+  // a final snapshot. The iterations captured so far reflect what was visible
+  // while scrolling UP — the very latest messages may have been below the
+  // viewport when the chat first opened (WA lands at the unread divider) and
+  // never got materialised into the DOM during scroll-up. The post-scroll
+  // tail snapshot, after a settle window, captures them.
+  await ensureScrolledToBottom(page);
+  const tailAria = await page.locator(":root").ariaSnapshot();
+  const tailMsgs = parseMessages(tailAria, { localeConfig, now: readNow });
 
-  // Merge: oldest iteration first, dedup
+  // Merge: oldest iteration first, dedup. Append tail last so any new
+  // messages take their proper "latest" position in insertion order.
   const merged = new Map();
   for (let i = iterations.length - 1; i >= 0; i--) {
     for (const msg of iterations[i]) {
       const key = dedupKey(msg);
       if (!merged.has(key)) merged.set(key, msg);
     }
+  }
+  for (const msg of tailMsgs) {
+    const key = dedupKey(msg);
+    if (!merged.has(key)) merged.set(key, msg);
   }
 
   // Post-dedup: remove ghost duplicates from scroll.
@@ -507,6 +551,12 @@ export async function read(page, chatName, { scroll = false, localeConfig, index
     // a follow-up if demand warrants.
     return scrollAndCollect(page, localeConfig);
   }
+  // Force scroll-to-bottom so WA's virtualized list materialises the latest
+  // rows before we snapshot. WA may open an active chat at the unread divider,
+  // leaving recent messages below the viewport and absent from the DOM —
+  // then ariaSnapshot returns a stale view and parseMessages silently drops
+  // them. Graceful degradation (no-op) if the scroll container can't be found.
+  await ensureScrolledToBottom(page);
   const readNow = new Date();
   // Capture `now` at read time so relative-date separators ("Ieri" / "Yesterday")
   // resolve deterministically against the snapshot's read moment, not against

--- a/test/scroll-to-bottom.test.js
+++ b/test/scroll-to-bottom.test.js
@@ -1,0 +1,64 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import * as commands from "../lib/commands.js";
+
+/**
+ * Build a fake Playwright page that records evaluate/snapshot calls and
+ * lets the test program the result of each evaluate invocation.
+ *
+ * `findScrollContainer` and the two scrollTop pins all go through
+ * `page.evaluate(fn)`. The fake exposes the call sequence so tests can
+ * assert WHEN scroll-to-bottom happened relative to ariaSnapshot.
+ */
+function makeFakePage({ findScrollResult = true } = {}) {
+  const calls = [];
+  const page = {
+    evaluate: async (fn) => {
+      // First call comes from findScrollContainer — record + return programmed
+      // result. Subsequent calls are the scrollTop pins; just record them.
+      const src = fn.toString();
+      if (src.includes("dataset.greentapScroll")) {
+        calls.push("findScrollContainer");
+        return findScrollResult;
+      }
+      if (src.includes("scrollHeight")) {
+        calls.push("scrollPin");
+        return undefined;
+      }
+      calls.push("evaluate:other");
+      return undefined;
+    },
+    locator: () => ({
+      ariaSnapshot: async () => {
+        calls.push("ariaSnapshot");
+        return "";
+      },
+    }),
+  };
+  return { page, calls };
+}
+
+describe("ensureScrolledToBottom", () => {
+  it("locates scroll container, then pins scrollTop twice with a settle in between", async () => {
+    const { page, calls } = makeFakePage({ findScrollResult: true });
+    const ok = await commands.ensureScrolledToBottom(page, 10); // tiny settle for tests
+    assert.equal(ok, true, "should return true when container found");
+    assert.deepEqual(calls, ["findScrollContainer", "scrollPin", "scrollPin"]);
+  });
+
+  it("returns false (no-op) when scroll container is not found — graceful degradation", async () => {
+    const { page, calls } = makeFakePage({ findScrollResult: false });
+    const ok = await commands.ensureScrolledToBottom(page, 10);
+    assert.equal(ok, false, "should return false when container missing");
+    // Only the locate call should have happened — no scroll pins attempted.
+    assert.deepEqual(calls, ["findScrollContainer"]);
+  });
+
+  it("waits for the requested settle window between the two pins", async () => {
+    const { page } = makeFakePage({ findScrollResult: true });
+    const t0 = Date.now();
+    await commands.ensureScrolledToBottom(page, 200);
+    const elapsed = Date.now() - t0;
+    assert.ok(elapsed >= 180, `should wait ~200ms, waited ${elapsed}ms`);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a bug where `read --json` (and `read --scroll`) drop the latest messages from active group chats while `chats --json` shows the correct latest preview.

**Symptom (2026-05-10):**
- `chats --json` correctly shows the last preview message
- `read --json`, `read --scroll --json`, `read --scroll --aria` all return a stale tail
- Multiple confirmations: read --scroll returns 100 msgs, read returns 40 msgs, both stop at the same stale tail

**Root cause:**
WhatsApp Web's message panel is virtualized. When `navigateToChat` opens an active chat, WA may land the viewport at the unread divider rather than the absolute bottom — leaving recent messages un-rendered in the DOM. The chat-list panel's preview reflects the actual latest message (separate DOM source), but the conversation pane's `ariaSnapshot` only captures the materialized window, so `parseMessages` silently drops messages whose rows haven't been mounted yet.

**Fix:**
Introduce `ensureScrolledToBottom(page, settleMs)` — locates the scroll container, pins `scrollTop=scrollHeight`, waits a settle window (default 700ms) for WA to materialize newly-revealed rows, then re-pins (the first scroll can shift layout while WA renders).

- `read()` non-scroll path: call before the initial `ariaSnapshot`, so `parseMessages` sees the latest rows.
- `scrollAndCollect()`: replaces the existing one-shot scroll-to-bottom with `ensureScrolledToBottom`, then takes a final **tail snapshot** and merges it into the iterations result. This catches messages that lived below the viewport during all the upward iterations and only materialized after the post-scroll settle.

Graceful degradation: if `findScrollContainer` can't locate the panel, `ensureScrolledToBottom` returns `false` and callers proceed with the previous behavior.

## Test plan

- [x] New unit tests in `test/scroll-to-bottom.test.js` (3 tests, all green): verify locate-then-double-pin sequence, graceful no-op when container missing, settle window honored.
- [x] Existing test suite still passes (the only failing tests on main — `navigateToChat: partial-match suggestions` — are pre-existing and unrelated).
- [ ] Manual validation:
  - `read '<active-group>' --json` includes the latest message
  - `read '<sandbox-group>' --json` doesn't regress
  - 5 consecutive reads of the same chat → same tail (timing stability)

🤖 Generated with [Claude Code](https://claude.com/claude-code)