### PR TITLE
chore(release): v0.6.0 — daemon + fetch-images + parser fixes, release/QA/PII hardening

### DIFF
--- a/.claude/skills/greentap/SKILL.md
+++ b/.claude/skills/greentap/SKILL.md
@@ -69,6 +69,9 @@ node greentap.js poll-results "contact or group name" --index 2 --json
 
 # Download recently-visible images from a chat to ~/.greentap/downloads/<chat-slug>/
 node greentap.js fetch-images "contact or group name" --limit 3 --json
+# --scroll loads older images first (mirrors read --scroll); --index N for duplicate names.
+# An invalid --limit (0, negative, non-numeric) warns on stderr and falls back to the default (20).
+node greentap.js fetch-images "contact or group name" --limit 5 --scroll --index 2 --json
 
 # E2E roundtrip verification against the dedicated greentap-sandbox group
 GREENTAP_E2E=1 node greentap.js e2e

--- a/.claude/skills/greentap/SKILL.md
+++ b/.claude/skills/greentap/SKILL.md
@@ -69,7 +69,9 @@ node greentap.js poll-results "contact or group name" --index 2 --json
 
 # Download recently-visible images from a chat to ~/.greentap/downloads/<chat-slug>/
 node greentap.js fetch-images "contact or group name" --limit 3 --json
-# --scroll loads older images first (mirrors read --scroll); --index N for duplicate names.
+# --scroll materializes more image rows into the DOM first (still bounded by
+# --limit and WhatsApp's blob lifetime — scrolled-off blobs may be unfetchable).
+# --index N disambiguates duplicate chat names.
 # An invalid --limit (0, negative, non-numeric) warns on stderr and falls back to the default (20).
 node greentap.js fetch-images "contact or group name" --limit 5 --scroll --index 2 --json
 

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,11 @@ summary_stats.txt
 *_msgs.json
 *_stats.txt
 
+# QA reports (may reference real chat data) + local PII token list
+qa-reports/
+greentap-pii-tokens
+!scripts/greentap-pii-tokens.example
+
 # Skills infrastructure (agent-deck, skills.sh)
 .agent/
 .agents/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,18 @@ npm test                             # Run all unit tests (node:test)
 | `test/fixtures/` | Recorded aria snapshots from live sessions |
 | `openspec/` | Specs, change proposals, workflow |
 
+## Daemon lifecycle
+
+The daemon (`lib/daemon.js`) is lazy-started on the first client call and self-exits after **15 min of no client connections**. Idle is tracked via a heartbeat file:
+
+- `~/.greentap/daemon.heartbeat` — `mtime` is "last client connect time"
+- Client (`lib/client.js`) calls `utimesSync` after every successful CDP connect
+- Daemon polls the file mtime every 60s; if `mtime` is older than `IDLE_TIMEOUT_MS` it shuts down
+
+The original CDP-event-based reset (`Target.attachedToTarget` listener on a session that only called `Target.setDiscoverTargets`) was a no-op for `connectOverCDP` clients — daemon died after exactly 15min regardless of activity. Fixed 2026-05-09.
+
+**Implication for cron-driven calls**: any caller hitting the daemon at intervals shorter than 15 min keeps it warm and avoids the 15-30s cold-start cost. Test isolation can override the timeout via `GREENTAP_IDLE_TIMEOUT_MS` (ms).
+
 ## openspec workflow
 
 See `openspec/WORKFLOW.md` for the full lifecycle.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -248,6 +248,17 @@ EOF
 )"
 ```
 
+### Post-merge branch cleanup
+
+After every merge to main, prune dangling branches:
+
+- **Local**: `git branch --merged main | grep -v "^\*\|main$" | xargs -r git branch -d`
+- **Remote**: `--delete-branch` flag is included in `gh pr merge` calls; verify with
+  `gh pr list --repo psacc/greentap --state closed --json headRefName --limit 50`
+  and the corresponding remote branches should not appear in
+  `git ls-remote --heads origin`.
+- **Be conservative**: never `git push --delete` on `main` or any release tag.
+
 ### Version bump rules
 
 - **Patch (`v0.x.y` → `v0.x.(y+1)`):** bug fixes only, no new
@@ -270,6 +281,20 @@ to re-clone or `git fetch + reset --hard origin/main`).
   (skills.sh indexing may take a few minutes)
 - Update the project memory with anything notable (next session's
   agent benefits from a tight summary of what shipped)
+
+### Post-tag local install verify
+
+After tagging + creating the GitHub release, verify the new version installs cleanly:
+
+1. `cd ~/prj/psacc/greentap && npm install -g .`
+2. `npm list -g greentap` → should show `greentap@<new-version>`
+3. `greentap --help` → renders without error
+4. If a major flag was added in this release, smoke-test it:
+   `greentap <command> --help | grep <new-flag>`
+
+If install fails or smoke test breaks, the release is broken; either revert
+the release (`gh release delete v<x.y.z>`, `git push --delete origin v<x.y.z>`)
+or ship a follow-up patch release immediately.
 
 ## PR checklist
 

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,65 @@
-.PHONY: build install clean
+SHELL := /bin/bash
+PKG_VERSION := $(shell node -p "require('./package.json').version" 2>/dev/null)
+LAST_TAG := $(shell git describe --tags --abbrev=0 2>/dev/null)
+SKILL := .claude/skills/greentap/SKILL.md
 
-PREFIX ?= $(HOME)/bin
+.PHONY: help test pii qa install-hooks release-check tag clean
 
-build:
-	swift build -c release
+help:
+	@echo "greentap make targets:"
+	@echo "  make test           run the unit suite (node:test) — NOT e2e"
+	@echo "  make pii            PII scan: tracked files + commit messages since last tag"
+	@echo "  make qa             pointer to the agentic QA runbook (docs/QA.md)"
+	@echo "  make install-hooks  install the pre-commit PII hook (opt-in, no deps)"
+	@echo "  make release-check  clean-tree + version-sync + tests + PII (pre-release gate)"
+	@echo "  make tag VERSION=vX.Y.Z   tag main + push (gated; refuses on drift/dirty/dup)"
+	@echo ""
+	@echo "  package.json version: $(PKG_VERSION)   last tag: $(LAST_TAG)"
+	@echo "  E2E is separate + machine-local: GREENTAP_E2E=1 node greentap.js e2e"
 
-install: build
-	mkdir -p $(PREFIX)
-	cp .build/release/greentap $(PREFIX)/greentap
+test:
+	npm test
+
+pii:
+	@./scripts/pii-scan.sh --worktree
+	@if [ -n "$(LAST_TAG)" ]; then ./scripts/pii-scan.sh --messages "$(LAST_TAG)..HEAD"; \
+	else echo "pii-scan: no previous tag; skipped commit-message range scan."; fi
+
+qa:
+	@echo "Agentic QA is a runbook, not a script — see docs/QA.md."
+	@echo "Run it on the release-prep PR (after 'make test' green) and paste"
+	@echo "the one-line verdict (QA: pass | pass with N notes | fail) on the PR."
+
+install-hooks:
+	@./scripts/install-hooks.sh
+
+release-check:
+	@echo "== release-check (pre-release gate; E2E is separate) =="
+	@if [ -n "$$(git status --porcelain)" ]; then \
+		echo "FAIL: working tree not clean"; git status --short; exit 1; fi
+	@echo "ok: clean tree"
+	@if grep -qE '^[[:space:]]*version:' "$(SKILL)" 2>/dev/null; then \
+		skv=$$(grep -E '^[[:space:]]*version:' "$(SKILL)" | head -1 | sed -E 's/.*version:[[:space:]]*"?([^"#]+)"?.*/\1/' | xargs); \
+		if [ "$$skv" != "$(PKG_VERSION)" ]; then \
+			echo "FAIL: version drift — package.json=$(PKG_VERSION) SKILL.md=$$skv"; exit 1; fi; \
+		echo "ok: version-sync ($(PKG_VERSION), package.json == SKILL.md)"; \
+	else \
+		echo "ok: version-sync (package.json=$(PKG_VERSION); SKILL.md carries no version field — skipped)"; fi
+	@$(MAKE) -s test && echo "ok: tests"
+	@$(MAKE) -s pii && echo "ok: PII scan"
+	@echo "release-check: PASS"
+
+tag:
+	@if [ -z "$(VERSION)" ]; then echo "usage: make tag VERSION=vX.Y.Z"; exit 2; fi
+	@branch=$$(git rev-parse --abbrev-ref HEAD); \
+	if [ "$$branch" != "main" ]; then echo "FAIL: not on main (on $$branch)"; exit 1; fi
+	@if [ -n "$$(git status --porcelain)" ]; then echo "FAIL: main not clean"; exit 1; fi
+	@vnum="$(VERSION)"; vnum="$${vnum#v}"; \
+	if [ "$$vnum" != "$(PKG_VERSION)" ]; then \
+		echo "FAIL: VERSION=$(VERSION) but package.json=$(PKG_VERSION)"; exit 1; fi
+	@if git rev-parse "$(VERSION)" >/dev/null 2>&1; then \
+		echo "FAIL: tag $(VERSION) already exists"; exit 1; fi
+	@git tag "$(VERSION)" && git push origin "$(VERSION)" && echo "tagged + pushed $(VERSION)"
 
 clean:
-	swift package clean
+	@echo "nothing to clean (no build artifacts; greentap is plain Node ESM)"

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ cp -r /path/to/greentap/.claude/skills/greentap ~/.claude/skills/greentap
 ## Testing
 
 ```sh
-npm test    # 53 unit tests (node:test), fixture-based
+npm test    # unit tests (node:test), fixture-based
 ```
 
 ## E2E testing

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,9 +1,9 @@
 ## Strategic context
-Priority: medium — stable, agent-autonomy + media shipped in v0.4.0
-Current phase: Phase 9 — quality polish (sticker visibility, performance, sender inheritance hardening) — target v0.5.0
+Priority: medium — stable; v0.5.1 shipped (reliability + read/nav/fetch fixes)
+Current phase: Phase 9 — quality polish + release-process maturity (omnisess-parity QA gate, automated PII guard) — target v0.6.0
 Blocks: nothing
 Blocked by: nothing
-Last updated: 2026-04-25
+Last updated: 2026-05-26
 → Full strategic context: psacc/docs/ROADMAP.md
 
 ---
@@ -41,7 +41,7 @@ Migrating to Playwright on WhatsApp Web, following the same pattern as hey-cli.
 | Aria tree restructuring (WA updates) | Medium | Two row formats already handled; parser may need updates. E2E harness catches breakage early. |
 | Sticker vs photo input confusion | Mitigated (2026-04-25) | E2E `sendFixtureImage` uses Allega → Foto e video flow keyed on `ic-filter-filled` icon; never touches the sticker input. |
 
-**Current: Phase 9 (quality polish, v0.5.0 target)**
+**Current: Phase 9 (quality polish + release-process maturity, v0.6.0 target)**
 
 ## Phases
 

--- a/docs/QA.md
+++ b/docs/QA.md
@@ -1,0 +1,408 @@
+# QA — Agentic QA Runbook
+
+How greentap uses an LLM subagent for pre-release QA. This is the runbook the
+maintainer follows on every release-prep PR. It complements — does not replace
+— `npm test` and the live `e2e` harness.
+
+## 1. Purpose + why
+
+`npm test` enforces correctness of pure logic (parser, arg parsing, JSON
+contract shape, e2e-guard enforcement) in isolation. `GREENTAP_E2E=1 node
+greentap.js e2e` verifies a **single live roundtrip** (text → image → link)
+against the sandbox group. Neither verifies **product-level sanity across the
+whole command surface**: does every user-facing command exit cleanly on bad
+args, emit a helpful (not stack-trace) error, and keep its `--json` shape
+stable? Does a refactor silently change an error message or drop a JSON key?
+
+Agentic QA closes that gap. A subagent walks every command with one golden and
+one designed-to-fail invocation, scores exit code / JSON shape / error quality,
+overlays the git-log risk since the last tag, and reports findings. It is one
+more cheap gate.
+
+**Motivating pattern** (borrowed from the omnisess QA runbook): code that
+compiles, passes CI, and still produces wrong output — e.g. an error message
+that leaks a stack trace, a `--json` invocation that prints human text, or a
+flag that's silently parsed into the chat name. Unit tests with mocked pages
+do not catch these end-to-end; a subagent invoking the real binary does.
+
+The agent does not replace human review. **FAIL blocks the merge.**
+
+## 2. When it runs
+
+- **Mandatory:** on every release-prep PR, **after `npm test` is green**,
+  **before merge**. The prep PR is the gate.
+- **Optional:** after a large refactor on `main`, as a smoke check.
+
+This sits alongside the existing pre-tag checklist in `CONTRIBUTING.md`
+("Pre-tag checklist"). Agentic QA is the product-sanity layer on top of
+`npm test` + live `e2e`. It does NOT replace the mandatory live `e2e` run.
+
+## 3. Data policy (PII constraint)
+
+**greentap reads real WhatsApp data during the LIVE checks** (`chats`,
+`unread`, `search`, `read`, `whoami` all surface real contacts, group names,
+message text, and the maintainer's own phone number). The repo is **public**.
+
+**Hard constraint on the agent's report content — never write PII into the
+report:**
+
+| Allowed | Forbidden |
+|---|---|
+| Exit codes (`0`, `1`, `2`, `3`) | Message text / chat content (verbatim or paraphrased) |
+| Counts (e.g. "chats returned N rows", "read returned M messages") | Real chat or group names — use `<chat-1>`, `<group-A>` |
+| Wallclock times | Real contact / sender names — use the fake personas only |
+| Structural shape ("keys: name, time, unread, lastMessage") | Phone numbers (incl. the account's own number from `whoami`) |
+| Boolean assertions ("`--json` parses as valid JSON: yes") | Absolute paths past the **basename** (`<imageId>.png` ✅, `/Users/<name>/.greentap/...` ❌) |
+| Error class / first line of stderr **if structural** | Any verbatim output excerpt longer than one line |
+| Fake personas: Roberto Marini, Elena Conti, Famiglia Rossi | Link preview hrefs pointing at real domains the user visits |
+
+If a check needs a chat name as input, use the **sandbox group**
+(`greentap-sandbox`) or a fake-persona placeholder — never a real chat.
+
+The OFFLINE matrix (§4) is PII-free by construction: it never connects to a
+live session, so no real data can enter the report. Prefer offline checks; the
+LIVE section (§5) is the only place real data is touched, and there the
+e2e harness already emits structural-only JSON.
+
+## 4. OFFLINE matrix (no live WhatsApp)
+
+For each command: one **golden** invocation and one **designed-to-fail**
+invocation that run **without** a live session. Assert four things per row:
+
+1. **Exit code** matches the expectation.
+2. **`--json` shape** — when the command supports `--json`, the golden path
+   prints a single line of valid JSON with the documented keys (verify the
+   keys, never the values).
+3. **Helpful error on bad args** — the failure path prints a `Usage:` line (or
+   a clear one-line message) to **stderr**, not stdout.
+4. **No stack-trace leak** — stderr on the failure path must NOT contain a
+   Node stack trace (`at Object.<anonymous>`, `at file://`, `node:internal`).
+   The top-level catch in `greentap.js` formats as `greentap error: <msg>` —
+   anything raw is a finding.
+
+### How to run the offline checks safely
+
+Most commands that target a chat will try to `connect()` to the daemon and open
+a live session — which would touch real data and is **not** offline. Keep those
+in the LIVE section. The offline matrix targets exactly the paths that fail
+(or print help) **before** any browser work:
+
+- **Arg-parsing failures** (missing required arg) — `greentap.js` prints
+  `Usage:` and `process.exit(1)` in the `switch` **before** calling
+  `withDaemon`. These are pure and offline-safe.
+- **Help / unknown command** — the `default` branch prints the usage block to
+  stdout with exit `0`. Offline-safe.
+- **`status`** — calls `daemonStatus()` only (reads a lockfile); no browser.
+  Offline-safe whether or not a daemon is running.
+- **`e2e` guard** — `greentap.js e2e` **without** `GREENTAP_E2E=1` prints
+  `e2e requires GREENTAP_E2E=1` to stderr and exits `1` before any browser
+  work. Offline-safe.
+- **`daemon` (bare)** — `greentap daemon` with no subcommand prints
+  `Usage: greentap daemon stop` (stdout, exit `0`). Offline-safe.
+
+For the **JSON-shape golden** of read-type commands (`chats`, `unread`,
+`read`, `search`, `whoami`, `poll-results`), do NOT spin up a live session in
+the offline phase. Instead assert the shape from the **unit test contract**
+(`test/cli.test.js` "JSON contract" describes) which exercises
+`parseChatList` / `parseMessages` / `parseSearchResults` / `whoami` against
+fixtures and asserts `JSON.stringify` round-trips. Treat "the JSON-contract
+tests in `npm test` are green" as the offline JSON-shape assertion, and route
+the live-data shape confirmation to §5.
+
+| Command | Golden (offline) | Designed-to-fail (offline) | Asserts | Live? |
+|---|---|---|---|---|
+| `chats` | JSON shape via `npm test` "JSON contract: chats" | — | keys: `name,time,unread,lastMessage` round-trip as JSON | live golden → §5 |
+| `unread` | JSON shape via `npm test` "JSON contract: unread" | — | same keys, `unread:true` subset | live golden → §5 |
+| `read` | JSON shape via `npm test` "JSON contract: read" | `greentap read` (no chat) → stderr `Usage: greentap read …`, exit `1` | message keys round-trip; usage on missing arg; no stack trace | live golden → §5 |
+| `search` | JSON shape via `npm test` "JSON contract: search" | `greentap search` (no query) → stderr `Usage: greentap search …`, exit `1` | result keys; usage on empty query | live golden → §5 |
+| `poll-results` | shape via parser unit tests | `greentap poll-results` (no chat) → stderr `Usage: greentap poll-results …`, exit `1` | usage on missing arg; no stack trace | live golden → §5 |
+| `fetch-images` | n/a offline (needs live blobs) | `greentap fetch-images` (no chat) → stderr `Usage: greentap fetch-images …`, exit `1` | usage on missing arg; no stack trace | live golden → §5 (image stage) |
+| `send` | n/a offline (mutating) | `greentap send <chat>` (no message) → stderr `Usage: greentap send …`, exit `1`; `greentap send` (no args) → same | usage on <2 args; no stack trace | live golden → §5 (text stage) |
+| `whoami` | shape `{name,phone}` via `npm test` whoami contract | — | `JSON.stringify` → `{name,phone}` (both nullable) | live golden → §5 |
+| `status` | `greentap status` → stdout `Daemon running…` or `No daemon running.`, exit `0` | — | clean exit; no browser; no PII | offline ✅ |
+| `snapshot` | n/a offline (needs live DOM) | (no offline failure path — defaults to `full` scope) | — | live → §5 (or skip; diagnostic only) |
+| `e2e` | n/a (live by definition) | `greentap e2e` **without** `GREENTAP_E2E=1` → stderr `e2e requires GREENTAP_E2E=1`, exit `1` | guard fires before browser; clean message | live golden → §5 |
+| `daemon` | `greentap daemon stop` → stdout `Daemon stopping…` or `No daemon running.`, exit `0` | `greentap daemon` (bare) → stdout `Usage: greentap daemon stop`, exit `0` | clean exit; no browser | offline ✅ |
+| `login` | n/a — launches a headed browser for QR scan; cannot assert headless | — | document as manual-only | manual (not automated) |
+| `logout` | n/a — destructive (clears `~/.greentap/browser-data`); never run in QA | — | document as destructive; do NOT invoke | never |
+| (help) | `greentap badcmd` or `greentap --help`-style → stdout usage block, exit `0` | — | usage printed; clean exit | offline ✅ |
+
+Notes:
+
+- **`logout` is destructive** (wipes the session). The QA agent MUST NOT run
+  it. Listed for completeness only.
+- **`login` opens a headed browser** and blocks on a window-close event. Not
+  automatable headless — manual smoke only.
+- For commands marked "live golden → §5", the offline phase only runs the
+  **failure path** + relies on `npm test` for JSON-shape; the **golden live
+  data** confirmation is the `e2e` harness in §5.
+
+## 5. LIVE checks
+
+**Do not reinvent the roundtrip.** Defer to the existing harness:
+
+```bash
+GREENTAP_E2E=1 node greentap.js e2e
+```
+
+It runs ordered stages against the `greentap-sandbox` group; first failure
+aborts. Output is structural JSON only (counts, paths, booleans — no message
+content). Exit codes: `0` pass · `1` stage failed · `2` sandbox missing ·
+`3` rate-limited (60s min between runs; override
+`GREENTAP_E2E_SKIP_RATE_LIMIT=1` for local debugging only).
+
+A `0` exit code is **necessary but not sufficient** — the feature's stage must
+have actually **run and passed** (not skipped). Read the stdout stage list.
+
+| Stage | Covers (exercised commands) | Known risk it guards |
+|---|---|---|
+| `preflight` | `navigateToChat` cold-state (grid-or-search, R5 fast-path) | "Chat not found" when a chat is already open (grid picks the message-panel grid); sandbox-group reachability |
+| `text` | `send` + `read` roundtrip | multi-line `Shift+Enter` send; `sender: "You"` own-message detection; read-returns-`[]` retry path; scroll-to-bottom materialization (Ponte 1-5-26 bug) |
+| `image` | `fetchImages` (attach correct photo input, not sticker) + blob extraction | wrong file-input targeted (sticker vs photo); revoked blob URLs; `--limit`/`slice(-N)` ordering |
+| `link` | `read` with `withLinks` + `collectRowLinks` + `mergeLinksIntoMessages` | URL-only message alignment by timestamp; greedy-monotone link merge |
+
+### Multimodal image-legibility check (mandatory when the image stage runs)
+
+After the `image` stage passes it emits `imagePath` and a `multimodalCheck`
+hint. The QA agent MUST `Read()` that path and confirm the text
+**`GREENTAP-E2E`** is legible in the pixels. A CLI `pass` with a blank or
+unreadable image means the pipeline is broken — record it as a **FAIL**.
+
+When reporting the multimodal result, follow §3: report only the basename
+(`<imageId>.png`) and the boolean ("GREENTAP-E2E legible: yes"), never the full
+path.
+
+### Live JSON-shape golden
+
+Optionally, against the **sandbox only** (E2E guard restricts every
+chat-targeting command to `greentap-sandbox`), confirm the live `--json`
+shapes:
+
+```bash
+GREENTAP_E2E=1 node greentap.js read greentap-sandbox --json
+GREENTAP_E2E=1 node greentap.js chats --json   # guard filters to sandbox row
+```
+
+Report only the **key set** and **row count**, never the values.
+
+## 6. Risk overlay — what changed since the last tag
+
+Compute the delta and exercise each change:
+
+```bash
+last_tag=$(git tag --sort=-v:refname | head -1)
+git log "$last_tag"..HEAD --oneline
+git diff --stat "$last_tag"..HEAD
+```
+
+| Commit type | Action |
+|---|---|
+| `feat:` | Identify the command/area; add one **deeper** offline exercise (more flags, `--index`, `--scroll`, `--limit`, `--json` combos). If it touches a live path, ensure the matching `e2e` stage runs. |
+| `fix:` | **Re-run the bug scenario** from the commit/PR body and confirm the fix is live (the bug no longer reproduces). |
+| `refactor:` | Re-run the touched command's regression suite (its unit tests) + the matching `e2e` stage if it touches a guarded path. |
+
+### Path-touched → re-exercise map
+
+| Path in diff | Re-exercise |
+|---|---|
+| `lib/parser.js` | `npm test` parser suite **and** live `e2e` text+link stages (read shape depends on parser) |
+| `lib/commands.js` | the affected command's offline failure path + the matching `e2e` stage (`send`→text, `fetchImages`→image, `read`→text/link, `navigateToChat`→preflight) |
+| `lib/client.js` / `lib/daemon.js` | `status` offline + daemon lifecycle; a full `e2e` run (preflight must actually connect, not just lockfile-check) |
+| `lib/locale.js` | live `e2e` (locale detection runs against the live chat list) + parser suite |
+| `lib/e2e.js` / `lib/e2e-guard.js` | `npm test` e2e-guard enforcement suite + a full `e2e` run |
+| `greentap.js` | the offline arg-parsing matrix in §4 (every `Usage:` and exit code) |
+| `test/fixtures/**` | `npm test` (fixtures are the parser's golden inputs) + the stage that consumes the fixture |
+
+Per `CONTRIBUTING.md`, any PR touching `lib/**` or `test/fixtures/**` MUST have
+already passed live `e2e` with the feature's stage active. The risk overlay
+re-confirms this at release-prep time across the cumulative `main` state.
+
+## 7. Performance budgets
+
+Measure wallclock per command (`/usr/bin/time -p`, or `time` in the shell).
+
+| Threshold | Outcome |
+|---|---|
+| `< 5 s` | PASS — silent |
+| `5 s ≤ t < 30 s` | PASS-WITH-NOTES — flag in report |
+| `t ≥ 30 s` | FAIL — likely hung |
+
+**Daemon cold-start caveat.** greentap is daemon-backed: the first command
+after the daemon idle-shuts-down (15-min idle timeout) pays the Chrome
+cold-start cost — empirically **15-30 s**. That first call can legitimately
+land in PASS-WITH-NOTES or near the FAIL line without indicating a regression.
+
+**Warm the daemon before timing** so budgets measure steady-state, not
+cold-start:
+
+```bash
+node greentap.js status        # cheap; does NOT start the daemon
+GREENTAP_E2E=1 node greentap.js e2e   # warms the daemon (preflight connects)
+# now time the commands you care about
+```
+
+If you measure a command that triggered the cold start, note it explicitly
+("first call after idle — cold start ~Ns") rather than recording a FAIL.
+
+## 8. PII allow/forbid table (report content)
+
+Repeated here as the agent's quick reference — see §3 for the rationale.
+
+| Allowed in the report | Forbidden in the report |
+|---|---|
+| Exit codes | Message text / chat content |
+| Counts (rows, messages, images) | Real chat / group names |
+| Wallclock times | Real contact / sender names |
+| Structural shape (key lists) | Phone numbers (incl. the account's own) |
+| Boolean assertions | Absolute paths past the basename |
+| First line of stderr **if structural** | Any verbatim excerpt > one line |
+| Fake personas (Roberto Marini, Elena Conti, Famiglia Rossi) | Real link-preview hrefs |
+
+When in doubt, redact to a placeholder (`<chat-1>`, `<group-A>`,
+`<imageId>.png`).
+
+## 9. Agent prompt template
+
+Copy-paste this into a Claude Code session when spawning the QA subagent.
+Fill `{{VERSION}}`, `{{PR}}`, `{{LAST_TAG}}`.
+
+```text
+You are the greentap release QA agent. Walk every user-facing command and
+produce a structured QA report for release {{VERSION}}, prep PR #{{PR}}.
+Last release tag: {{LAST_TAG}}.
+
+## Setup (once)
+1. cd to the repo root.
+2. Confirm npm test is green:  npm test
+3. Confirm the version:  node -p "require('./package.json').version"  (== {{VERSION}})
+4. Compute the change delta:
+     git log {{LAST_TAG}}..HEAD --oneline
+     git diff --stat {{LAST_TAG}}..HEAD
+
+## OFFLINE matrix (docs/QA.md §4) — run these; they need NO live session
+- For each row's designed-to-fail invocation, capture: exit code, whether
+  stderr has a `Usage:`/clear message, and that stderr has NO Node stack trace.
+  Examples:
+    node greentap.js read                     # expect exit 1, "Usage: greentap read"
+    node greentap.js send <chat>              # expect exit 1, "Usage: greentap send"
+    node greentap.js search                   # expect exit 1, "Usage: greentap search"
+    node greentap.js poll-results             # expect exit 1, "Usage: greentap poll-results"
+    node greentap.js fetch-images             # expect exit 1, "Usage: greentap fetch-images"
+    node greentap.js e2e                      # expect exit 1, "e2e requires GREENTAP_E2E=1"
+    node greentap.js daemon                   # expect exit 0, "Usage: greentap daemon stop"
+    node greentap.js status                   # expect exit 0, clean
+    node greentap.js badcmd                   # expect exit 0, usage block
+- For JSON-shape goldens of read-type commands, rely on the npm test
+  "JSON contract" describes (do NOT open a live session in this phase).
+- NEVER run `node greentap.js logout` (destructive) or `login` (headed/manual).
+
+## LIVE checks (docs/QA.md §5) — defer to the harness, do NOT reinvent
+    GREENTAP_E2E=1 node greentap.js e2e
+- Confirm exit 0 AND that the stage(s) touching this release's changes actually
+  RAN (read the stdout stage list — not skipped/preflight-only).
+- When the image stage runs: Read() the emitted imagePath and confirm the text
+  "GREENTAP-E2E" is legible. Report only the basename + a boolean.
+
+## Risk overlay (docs/QA.md §6)
+- For each feat/fix/refactor since {{LAST_TAG}}, add the exercise the table
+  prescribes; map path-touched -> stage/command and re-run it.
+
+## Performance (docs/QA.md §7)
+- Warm the daemon first (run e2e once), THEN time commands. Cold start (15-30s
+  after idle) is a NOTE, not a FAIL.
+
+## Data policy (docs/QA.md §3 + §8) — CRITICAL
+Your report MUST NOT contain: message text, real chat/group names, real
+contact/sender names, phone numbers (incl. the account's own), absolute paths
+past the basename, or any verbatim output excerpt longer than one line.
+You MAY include: exit codes, counts, wallclock, structural key lists, boolean
+assertions, and the first structural line of stderr. Redact to placeholders
+(<chat-1>, <group-A>, <imageId>.png). Use only the fake personas
+(Roberto Marini, Elena Conti, Famiglia Rossi) if a name is needed.
+
+## Output
+- Write the full report to:  qa-reports/{{VERSION}}.md  (format in §10).
+- Emit (do NOT post) a single verdict line at the very end of your response,
+  on its own line, exactly one of:
+     QA: pass
+     QA: pass with N notes
+     QA: fail — <one-clause summary>
+- Do NOT call `gh`. Return the report path + the verdict line. The MAINTAINER
+  posts it to the PR.
+
+Return to the maintainer:
+1. Path to the local report.
+2. The one-line verdict.
+3. Nothing else.
+```
+
+## 10. Output
+
+The agent writes the full report to:
+
+```
+qa-reports/<version>.md
+```
+
+> **Gitignore flag (action for the maintainer):** `qa-reports/` should be
+> **gitignored** — reports describe runs against real WhatsApp data and the
+> repo is public. As of this writing `.gitignore` does NOT contain a
+> `qa-reports/` entry. **Add `qa-reports/` to `.gitignore` before the first
+> report is generated.** (This runbook does not edit `.gitignore` itself.)
+
+### Report format (`qa-reports/<version>.md`)
+
+```markdown
+# QA Report — vX.Y.Z (prep PR #NN)
+
+_Generated: <UTC timestamp>_
+_Last release: <last tag>_
+_Host: darwin_
+
+## Outcome: <PASS | PASS-WITH-NOTES | FAIL>
+
+<one-paragraph summary — PII-free>
+
+## Offline matrix
+| Command | Invocation | Exit | Stack-trace-free | Outcome | Observation |
+|---|---|---|---|---|---|
+| read (fail path) | `read` (no chat) | 1 | yes | PASS | stderr first line: `Usage: greentap read …` |
+| ... | | | | | |
+
+## Live (e2e)
+| Stage | Ran | Exit | Outcome | Observation |
+|---|---|---|---|---|
+| preflight | yes | — | PASS | sandbox reachable |
+| text | yes | — | PASS | marker round-tripped, sender=You |
+| image | yes | — | PASS | GREENTAP-E2E legible: yes (<imageId>.png) |
+| link | yes | — | PASS | marker href matched |
+
+## Risk overlay (since <last tag>)
+`<commit subject>` (feat/fix/refactor) — exercise: `<command/stage>` — outcome — <observation>
+
+## Performance notes
+<empty if all < 5s after warm-up; flag cold starts explicitly>
+
+## Skipped
+- `login` — manual only (headed browser)
+- `logout` — destructive, never run
+```
+
+### Verdict + posting boundary
+
+The agent emits **one** verdict line as text; the **maintainer** posts it to
+the PR. The agent never calls `gh`.
+
+| Outcome | Verdict line | Action |
+|---|---|---|
+| **PASS** | `QA: pass` | Merge once human review is also OK + merge protocol satisfied. |
+| **PASS-WITH-NOTES** | `QA: pass with N notes` | Read the notes; decide block-or-land. Document the call in the prep PR body if shipping anyway. |
+| **FAIL** | `QA: fail — <one-clause summary>` | **Blocks merge.** Fix, re-run QA, re-status. |
+
+`QA: fail` blocks the merge. No exceptions. The full report stays local at
+`qa-reports/<version>.md`; only the one-line verdict goes on the PR.
+
+This agent-emits / maintainer-posts split is a deliberate autonomy boundary
+(consistent with the iron-clad merge protocol in `CLAUDE.md` and
+`CONTRIBUTING.md`). The QA verdict informs the merge decision; it never makes
+it.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -94,7 +94,11 @@ remaining items are re-verified on `main` in Stage 2.)
   cumulative E2E gate is a Stage 2 item, per `CONTRIBUTING.md` § "E2E is mandatory".)
 - **PII scan clean** — `make pii` over the diff and over every commit message
   since the previous tag. Forbidden-token list lives in `CONTRIBUTING.md` §
-  "PII patterns". This applies to doc-only release PRs too.
+  "PII patterns". This applies to doc-only release PRs too. **Before trusting a
+  "clean" result, confirm `.git/greentap-pii-tokens` exists** (copy from
+  `scripts/greentap-pii-tokens.example`) — without it the scan is
+  STRUCTURAL-only and will not catch maintainer name/email/identity leaks (the
+  exact category of the 2026-04-27 incident).
 - **Skill-coherence `COHERENT`** — run the checker (`docs/skill-coherence-checker.md`).
   Any new command or new JSON field added since the previous tag MUST already
   be documented in `SKILL.md`. Verdict must read `COHERENT`.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,237 @@
+# Release Runbook
+
+Authoritative orchestration runbook for cutting a greentap release.
+
+This is the step-by-step **how**. The **rules** it enforces live elsewhere
+and are cross-referenced, not duplicated:
+
+- **Merge approval protocol** → `CONTRIBUTING.md` § "Merge approval protocol"
+- **E2E gate (real WhatsApp Web roundtrip)** → `CONTRIBUTING.md` § "E2E is mandatory"
+- **PII patterns + forbidden tokens** → `CONTRIBUTING.md` § "PII patterns"
+- **Pre-tag checklist + version bump rules** → `CONTRIBUTING.md` § "Release procedure"
+- **Agentic QA gate** → `docs/QA.md` (authored separately)
+- **Release-notes template + privacy style-guide** → `docs/release-notes-template.md`
+
+If anything here ever contradicts `CONTRIBUTING.md`, `CONTRIBUTING.md` wins for
+the rule and this file is corrected.
+
+---
+
+## The shape of a release
+
+Two stages, deliberately separated:
+
+1. **Release-prep PR** — carries the version bump and the QA verdict, merges
+   into `main` through normal branch protection.
+2. **Tag + publish** — from `main` after the prep PR lands; tags, pushes the
+   tag, creates the GitHub release with hand-written notes.
+
+Why two stages: branch protection blocks committing at tag time. The version
+bump and the QA verdict must already be on `main` before the tag points at a
+commit. Tagging is the last step, never the first.
+
+---
+
+## Versioning (semver, `v0.<minor>.<patch>`)
+
+greentap is `0.x` — the public contract is not yet frozen.
+
+| Bump | When | Example |
+|------|------|---------|
+| **Patch** | Bug fixes only. No new commands, no new flags, no new output fields, no contract changes. | `v0.5.1` → `v0.5.2` |
+| **Minor** | Additive only: new command, new flag, new field in read/JSON output. Backward-compatible. | `v0.5.1` → `v0.6.0` |
+| **Major** | Reserved for the stability commitment (freezing the CLI + JSON contract). A breaking change — removing/renaming a field or command — only happens here. Not used while `0.x`. | `v0.x.y` → `v1.0.0` |
+
+When in doubt between patch and minor: if a consumer could write new code
+against it, it is minor.
+
+---
+
+## Stage 1 — Release-prep PR
+
+Goal: land a `main` commit that already carries the new version and a passing
+QA verdict.
+
+### 1. Start from clean `main`
+
+```bash
+git checkout main
+git pull origin main
+git status            # must be clean
+make release-check    # version-sync + clean tree + tests + PII scan (see "Release scripts")
+```
+
+### 2. Pick the version
+
+Apply the semver table above. Use the full `vX.Y.Z` form everywhere.
+
+### 3. Branch and bump
+
+```bash
+git checkout -b chore/release-prep-vX.Y.Z
+```
+
+Bump the version in **both** of these — they MUST stay in sync:
+
+- `package.json` (`"version"` field)
+- `.claude/skills/greentap/SKILL.md` (the skill's declared version, when the
+  frontmatter carries one)
+
+These two are the only sources of truth for "what version is this". If they
+drift, `make release-check` fails (see "Release scripts"). Commit:
+
+```bash
+git commit -am "chore(release): bump version to X.Y.Z"
+```
+
+### 4. Run the PR-time slice of the Pre-tag checklist
+
+These are the items that are meaningful on the branch, before merge. (The full
+Pre-tag checklist lives in `CONTRIBUTING.md` § "Release procedure" — the
+remaining items are re-verified on `main` in Stage 2.)
+
+- **`make test` green** — unit tests pass. (`npm test` passing is NOT e2e; the
+  cumulative E2E gate is a Stage 2 item, per `CONTRIBUTING.md` § "E2E is mandatory".)
+- **PII scan clean** — `make pii` over the diff and over every commit message
+  since the previous tag. Forbidden-token list lives in `CONTRIBUTING.md` §
+  "PII patterns". This applies to doc-only release PRs too.
+- **Skill-coherence `COHERENT`** — run the checker (`docs/skill-coherence-checker.md`).
+  Any new command or new JSON field added since the previous tag MUST already
+  be documented in `SKILL.md`. Verdict must read `COHERENT`.
+
+### 5. Run the Agentic QA gate
+
+Run the agentic QA per `docs/QA.md`. It exercises the user-facing surface and
+emits a single-line verdict. Paste that one line verbatim as a comment on the
+prep PR, e.g.:
+
+```
+QA: pass
+QA: pass with N notes
+QA: fail — <one-line reason>
+```
+
+`QA: fail` blocks the merge. Fix, re-run, re-post the verdict.
+
+### 6. Open the PR
+
+```bash
+git push -u origin chore/release-prep-vX.Y.Z
+gh pr create --title "chore(release): bump version to X.Y.Z" \
+  --body-file .github/pull_request_template.md
+```
+
+Fill in the template body. Include the QA verdict line.
+
+### 7. Get explicit, per-PR approval — then merge
+
+Per the **iron-clad merge protocol** (`CONTRIBUTING.md` § "Merge approval
+protocol"):
+
+- Every merge needs explicit maintainer approval, **per-PR and per-session**.
+  The maintainer must say "merge it" (or equivalent) for *this* PR, *this*
+  session. A generic "procedi" / "continue" does NOT authorize a merge — it
+  authorizes work up to `gh pr create`, then stop and ping.
+- `gh pr merge --admin` / any branch-protection bypass is **FORBIDDEN** unless
+  the maintainer explicitly says "use admin" for this specific PR.
+- When in doubt: ping and wait.
+
+Only after that explicit OK, merge the prep PR.
+
+---
+
+## Stage 2 — Tag + publish
+
+Goal: tag the `main` commit that carries the version bump, then publish.
+
+### 8. Re-verify `main`
+
+```bash
+git checkout main
+git pull origin main
+make release-check
+```
+
+Then re-verify the **full** Pre-tag checklist on `main` HEAD per
+`CONTRIBUTING.md` § "Release procedure". In particular:
+
+- **`main` is clean**, all PRs intended for this release are merged.
+- **`make test` green on `main` HEAD.**
+- **Cumulative E2E green on `main` HEAD** — `GREENTAP_E2E=1 node greentap.js e2e`
+  must exit `0` AND the stage(s) exercising what shipped must actually run (not
+  skipped). Per-PR e2e catches each change in isolation; this re-run catches the
+  cumulative state of `main`. Full gate, scope, pass criteria, and the
+  multimodal image check are in `CONTRIBUTING.md` § "E2E is mandatory".
+- **Skill coherence `COHERENT`** and **PII scan clean** on `main` HEAD.
+
+If any item is red, the release is **blocked** until fixed (the fix is itself a
+new PR through Stage 1's protocol).
+
+### 9. Tag (gated on maintainer OK)
+
+Tagging and pushing the tag is part of "publishing" — treat the maintainer's
+"merge it" for the prep PR as covering the *merge only*. Confirm the maintainer
+also wants the tag pushed for *this* version, this session, before pushing.
+
+```bash
+make tag VERSION=vX.Y.Z      # verifies version-sync + clean main, then tags + pushes
+```
+
+Verify the tag points at the intended commit SHA before continuing.
+
+### 10. Create the GitHub release
+
+Write the notes by hand using `docs/release-notes-template.md` (privacy
+style-guide is part of that file). Do **not** ship raw `--generate-notes`
+output — it may surface a flat PR list and is a starting point only.
+
+```bash
+# Draft the body into a local file first (gitignored / /tmp — never committed).
+gh release create vX.Y.Z \
+  --title "vX.Y.Z — <short title>" \
+  --notes-file /tmp/vX.Y.Z-notes.md
+```
+
+### 11. Post-tag verification
+
+- GitHub release page renders correctly, hand-written notes visible:
+  `gh release view vX.Y.Z`
+- `npx skills add psacc/greentap` picks up the new version (skills.sh indexing
+  may lag a few minutes).
+- Update project memory with a tight summary of what shipped.
+
+---
+
+## Release scripts
+
+These commands are assumed to exist (built separately — do not implement them
+here). This section is the spec of what each must verify.
+
+| Command | Must verify |
+|---------|-------------|
+| `make test` | Runs the unit suite (`node:test`). Exits non-zero on any failure. This is NOT e2e — it does not touch WhatsApp Web. |
+| `make pii` | Runs the PII scan over the working tree / diff and over every commit message since the previous tag, against the forbidden-token list in `CONTRIBUTING.md` § "PII patterns". Exits non-zero if any forbidden token is found. Tracked files only. |
+| `make release-check` | Composite gate: (1) **version-sync** — `package.json` version equals the `SKILL.md` declared version; (2) **clean tree** — no uncommitted/untracked changes; (3) **tests** — runs `make test`; (4) **PII scan** — runs `make pii`. Exits non-zero if any sub-check fails. Does NOT run e2e (that is a separate, machine-local gate). |
+| `make tag VERSION=vX.Y.Z` | Re-checks version-sync and a clean `main`, then creates the `vX.Y.Z` tag on the current `main` commit and pushes it to origin. Refuses to tag if version-sync fails or the tag already exists. |
+
+`make release-check` is the fast local pre-flight for both stages. The E2E gate
+is intentionally **not** folded into it — e2e is machine-local, slow, and gated
+separately in `CONTRIBUTING.md` § "E2E is mandatory".
+
+---
+
+## Quick reference
+
+```
+Stage 1 (PR):   clean main → branch chore/release-prep-vX.Y.Z
+              → bump package.json + SKILL.md (in sync)
+              → make test green, make pii clean, skill-coherence COHERENT
+              → run docs/QA.md, paste verdict on PR
+              → gh pr create → EXPLICIT per-PR maintainer OK → merge
+
+Stage 2 (tag):  main green + cumulative E2E green (CONTRIBUTING.md)
+              → maintainer OK to push tag
+              → make tag VERSION=vX.Y.Z
+              → gh release create with docs/release-notes-template.md notes
+              → verify release page + skills.sh + update memory
+```

--- a/docs/known-leaks.md
+++ b/docs/known-leaks.md
@@ -1,0 +1,72 @@
+# Known leaks
+
+Per `CONTRIBUTING.md` § "PII patterns": a PII leak found in commits **already
+inside a tagged release** is **not** rewritten (rewriting published history is
+a one-way door with audit-trail cost). Instead it is documented here — SHA +
+content category only, never the leaked content itself — and prevention is
+applied going forward.
+
+This file intentionally contains **no PII**. It records *that* a leak
+happened, its category and scope, and the remediation — not the leaked values.
+
+---
+
+## 2026-04-27 — PII in GitHub release notes
+
+- **What:** Personally-identifying content appeared in a greentap GitHub
+  **release note** (release-description text on the GitHub Releases page), in
+  the v0.4.0 → v0.5.0 timeframe. Release-note text lives in GitHub's release
+  API, not in the git tree, so this was not a commit-content leak.
+- **Category:** maintainer identity / chat-derived content (exact values not
+  reproduced here).
+- **Scope:** GitHub Releases page only.
+- **Root cause:** unreviewed batch push + manual-grep-only PII defense (a CoE
+  was filed for the broader 4/27 "5 unreviewed commits to public repo" lapse).
+- **Remediation:** release notes corrected. Prevention added 2026-05-26:
+  automated PII scanner + pre-commit hook (`scripts/pii-scan.sh`,
+  `scripts/install-hooks.sh`), release-notes privacy template
+  (`docs/release-notes-template.md`), and the QA PII allow/forbid table
+  (`docs/QA.md`).
+- **Backup tags (local-only, NOT on public origin — verified 2026-05-26):**
+  `pii-leak-backup-2026-04-27`, `pre-oss-rewrite`. These preserve pre-rewrite
+  state for recovery and must never be pushed to origin.
+
+---
+
+## OPEN / UNDER REVIEW — `pre-swift-removal` tag on public origin
+
+> Status: **flagged 2026-05-26, awaiting maintainer decision.** Not yet
+> remediated. Listed here so it is not lost.
+
+- **What:** The tag `pre-swift-removal` (commit `b2bb0c1`, 2026-03-08 01:17) is
+  present on the **public** `origin`. It **predates** the fixture-anonymization
+  commit `7bbb746` ("anonymize fixtures and remove openspec archives for OSS
+  prep", 2026-03-08 14:36) — confirmed: `7bbb746` is **not** an ancestor of the
+  tag. The tag's tree still contains `test/fixtures/` (4 files).
+- **Implication:** the tag likely exposes **pre-anonymization** fixture data
+  (real chat content / names / numbers) publicly, reachable via
+  `git fetch origin tag pre-swift-removal` or the tag page on GitHub.
+- **Recommended remediation (needs maintainer OK — deleting a public tag is a
+  visible, hard-to-fully-reverse action):**
+  1. Confirm the pre-anonymization fixtures actually contained PII (review
+     locally, do not paste content).
+  2. If so: delete the tag on origin (`git push origin :refs/tags/pre-swift-removal`)
+     and locally; consider whether any other ref keeps those commits reachable.
+  3. Note that the data may already be cloned/cached/indexed elsewhere —
+     deletion reduces but does not guarantee removal of public exposure.
+
+---
+
+## OBSERVATION — first names in committed fixture message bodies
+
+> Status: **observation, 2026-05-26.** Not confirmed as PII; for review.
+
+- **What:** Current `test/fixtures/main-aria.txt` / `chat-aria.txt` message
+  *bodies* contain first names (e.g. in French-language sample messages).
+  Group names, phone numbers (all-zeros synthetic), and links (REDACTED /
+  example.com) appear anonymized, but body text retains given names.
+- **Question for review:** are these invented or residual real first names? If
+  residual, they are in tagged releases (v0.x) → document-don't-rewrite per
+  policy, and scrub in a future fixture refresh.
+- **Action:** routed to the QA pilot + code/security review for a judgment;
+  no history rewrite without maintainer decision.

--- a/docs/known-leaks.md
+++ b/docs/known-leaks.md
@@ -33,10 +33,14 @@ happened, its category and scope, and the remediation — not the leaked values.
 
 ---
 
-## OPEN / UNDER REVIEW — `pre-swift-removal` tag on public origin
+## REMEDIATED 2026-05-26 — `pre-swift-removal` tag on public origin
 
-> Status: **flagged 2026-05-26, awaiting maintainer decision.** Not yet
-> remediated. Listed here so it is not lost.
+> Status: **remediated 2026-05-26.** Tag deleted from `origin` and locally
+> (maintainer authorized deleting all non-semver / non-release tags). The
+> related local-only backups `pre-oss-rewrite` and `pii-leak-backup-2026-04-27`
+> were deleted in the same pass. Residual risk: GitHub may retain the unreferenced
+> objects until garbage-collection, and any prior clone/fork/cache/index is
+> outside our control — deletion reduces but does not guarantee removal.
 
 - **What:** The tag `pre-swift-removal` (commit `b2bb0c1`, 2026-03-08 01:17) is
   present on the **public** `origin`. It **predates** the fixture-anonymization

--- a/docs/release-notes-template.md
+++ b/docs/release-notes-template.md
@@ -1,0 +1,70 @@
+# Release-notes template
+
+The mandatory structure for every greentap GitHub release body. Copy the block
+below, fill it in, delete any section that has no entries. Notes are written by
+hand — `--generate-notes` output is a starting point, not the deliverable.
+
+The release notes are the **most public artifact** of this repo. The privacy
+style-guide below is not optional. (Forbidden-token detail lives in
+`CONTRIBUTING.md` § "PII patterns".)
+
+---
+
+## Privacy + style rules
+
+- **No PII.** No real names, emails, phone numbers, or chat content. If an
+  example is unavoidable, use the established fake personas (Roberto Marini,
+  Elena Conti, Famiglia Rossi) or placeholders (`<chat>`, `<maintainer>`).
+- **No `/Users/<name>/` paths.** Use `~/.greentap/...` or `<home>/...`. Never
+  paste an absolute path that contains a username.
+- **No real chat names or IDs.** No real group names, contact references, or
+  WhatsApp internal IDs.
+- **Numbers, not adjectives.** "Read now scrolls to bottom before snapshot,
+  capturing the latest N messages" beats "much better message capture". Use
+  measured numbers; avoid raw personal data.
+- **Action over implementation.** Describe what the user can now do, not the
+  internal refactor that enabled it.
+- **Known issues belong in the notes**, not only in the tracker. Surfacing them
+  up front is part of the contract with users — concealing them costs more trust
+  than admitting them.
+- **Link work where it helps.** Reference the PR/issue (`#NN`) for non-trivial
+  bullets.
+
+---
+
+## Template (copy from here)
+
+```markdown
+# vX.Y.Z — <short title>
+
+<One-paragraph headline — the 1–2 things a reader cares about most.>
+
+## Highlights
+
+- Lead bullet: the headline change, in user terms.
+- Second-most-important change.
+
+## All changes
+
+- One bullet per user-visible change. Lead with the command/flag/field, then a
+  one-line "what it does". Link the PR (#NN).
+- (Derive from `git log <prev-tag>..vX.Y.Z --oneline`. Trim trivial/chore
+  commits. Group by category if the list is long.)
+
+## Upgrade notes
+
+- Backward-compat statement (default for a minor/patch: "CLI surface and JSON
+  output are backward-compatible").
+- Anything the user must do manually: re-login (QR scan), new on-disk artifacts
+  under `~/.greentap/`, contract changes.
+- If git history was rewritten on `main` for PII reasons, say so: consumers with
+  an old clone must re-clone or `git fetch && git reset --hard origin/main`.
+- If nothing: "None."
+
+## Known limits
+
+- Issues shipping with this release, one bullet each, link the issue (#NN).
+- Carry-over warnings from `CONTRIBUTING.md` / `SKILL.md` / `ROADMAP.md` that
+  still apply (e.g. low-volume personal use only; aria-snapshot structure may
+  change with WhatsApp Web updates).
+```

--- a/docs/superpowers/specs/2026-05-26-release-process-and-stabilization-design.md
+++ b/docs/superpowers/specs/2026-05-26-release-process-and-stabilization-design.md
@@ -1,0 +1,177 @@
+# Design: Release-process hardening + v0.6.0 stabilization
+
+**Date:** 2026-05-26
+**Status:** awaiting maintainer approval
+**Author:** Claude (orchestrated, multi-subagent)
+
+## Goal
+
+Bring greentap's release process up to the maturity level of `psacc/omnisess`
+— in particular a real **QA gate** — while cleaning up accumulated debt
+(stale branches, stashes, dead Makefile, red tests, unmerged work) and
+closing the automated-PII-guard gap that caused the 2026-04-27 leak. End
+state: a more stable, releasable **v0.6.0** with artifacts prepared and
+**every merge/tag/remote-push held for explicit per-PR maintainer OK**.
+
+Repo is **public**: no PII in any committed file. Local work proceeds
+freely; anything that publishes (PR merge, tag, push) is gated.
+
+## Locked decisions (approved 2026-05-26)
+
+1. **Release scope → v0.6.0** = stability fixes + salvage daemon idle-death
+   fix (Todoist #9) + fetch-images `--limit` fix (Todoist #6). The two
+   salvaged fixes touch `lib/` → **E2E MANDATORY** before their PRs merge.
+2. **PII guard → automated** pre-commit hook + scan script (no new deps).
+3. **Cleanup → prune now**, local + remote stale merged branches + drop the
+   2 obsolete stashes.
+
+## Current-state findings (evidence)
+
+- GitHub: 0 open PRs/issues. Backlog is local + Todoist (12 greentap tasks).
+- `main` is **red**: 2 failing tests in `test/navigate.test.js:322,345` — a
+  PII-sanitization artifact (`GROUP_X` placeholder doesn't contain the query
+  `"Foot"`, so it's correctly excluded from partial-match candidates, but the
+  assertions still expect it). v0.5.0 + v0.5.1 were tagged red.
+- 17 stale **remote** branches = squash-merged PRs (#15–#34); safe to prune.
+  3 branches hold genuinely unmerged work:
+  `fix/daemon-heartbeat-idle-reset` (local-only, daemon idle fix),
+  `fix/greentap-5-bugs-2026-04-25` (fetch-images `--limit`),
+  `chore/contributing-cleanup-and-install` (docs, superseded).
+- 2 stashes: stale snapshots of already-merged work (PRs #16/#18/#19).
+- PII defense is **manual grep only** → the exact failure mode of 4/27.
+  `docs/known-leaks.md` is referenced (CONTRIBUTING.md:66) but **missing**.
+- Dead Swift `Makefile` (Swift removed in Phase 4). No lint/release scripts.
+- ROADMAP strategic block stale (targets v0.5.0; we're at v0.5.1).
+
+## Workstreams
+
+PRs are grouped so the E2E-exempt bulk can move independently of the
+E2E-gated lib salvage.
+
+### PR A — Stabilization + release process (E2E-exempt: docs/tooling/test-only)
+
+A1. **Fix red tests** — `test/navigate.test.js`: rename the fixture chat so
+    it shares the `"Foot"` prefix (e.g. `Football`) OR relax the two
+    assertions to expect only the genuine match. Target: `npm test` green.
+    (Test file, not `test/fixtures/**` → E2E-exempt.)
+
+A2. **PII automation** — `scripts/pii-scan.sh`:
+    - Ships only **structural** patterns (phone regex `+\d{10,15}` minus the
+      synthetic allowlist; `/Users/<username>/` paths; task-tracker URL
+      shapes).
+    - Reads **identity-specific** forbidden tokens (maintainer name/email/
+      domain) from a **gitignored** local file (`.git/greentap-pii-tokens`
+      or `~/.greentap/pii-tokens`), never from a tracked file
+      (CONTRIBUTING.md:25 forbids committing real tokens).
+    - Modes: `--staged` (pre-commit), `--range <a>..<b>` (release/pre-tag),
+      `--messages` (commit messages). Non-zero exit on any hit.
+    - Pre-commit hook installer: `scripts/install-hooks.sh` writes a plain
+      `.git/hooks/pre-commit` calling the scanner (no husky dep). Documented
+      so a fresh clone can opt in.
+    - `npm run pii` wired in; release script calls the range+messages scan.
+
+A3. **Release process** — replace the dead Swift `Makefile` with real
+    targets (or npm scripts): `test`, `pii`, `qa` (prints runbook pointer),
+    `release-check` (version sync + clean tree + tests + PII), `tag`.
+    Add `RELEASE.md` documenting the **two-stage flow** (release-prep PR
+    carrying version bump + QA verdict → after merge, tag + `gh release`),
+    adapted from omnisess. Add a release-notes template with the privacy
+    style-guide ("numbers not adjectives", no `/Users/<name>/`, no real
+    IDs). Version-sync guard: `package.json` version ↔ tag ↔ `SKILL.md`.
+
+A4. **Agentic QA runbook** — `docs/QA.md`, adapted from omnisess
+    `TESTING.md`:
+    - Per-command golden + designed-to-fail matrix for every user-facing
+      command (`chats`, `unread`, `read`, `search`, `poll-results`,
+      `fetch-images`, `send`, `whoami`, `status`, `snapshot`), asserting
+      JSON-contract shape + exit codes.
+    - **Risk overlay**: `git log <last-tag>..HEAD` — each `feat:` gets a
+      deeper exercise, each `fix:` re-runs the bug scenario to confirm it's
+      live, each `refactor:` re-runs the touched command's regression suite.
+    - **Perf budgets** (wallclock): `<5s` PASS, `5–30s` PASS-WITH-NOTES,
+      `≥30s` FAIL (likely hung) — cold-start daemon caveat documented.
+    - **PII allow/forbid table** for report content (greentap reads real
+      WhatsApp data): counts/exit-codes/wallclock allowed; message
+      previews / full chat names / phone numbers forbidden.
+    - **Live-vs-offline split**: which checks need a live WhatsApp session
+      (read/send/fetch/poll roundtrips → the existing `e2e` harness) vs.
+      which run offline (JSON contracts, arg parsing, error paths, `status`,
+      `--help`). Report goes to `qa-reports/<version>.md` (gitignored).
+    - **Agent-emits / human-posts** boundary: the QA subagent writes the
+      report + a one-line verdict; the maintainer relays it. The agent never
+      posts to GitHub.
+
+A5. **Cleanup** — delete 17 stale merged remote branches + local copies;
+    drop the 2 obsolete stashes; create `docs/known-leaks.md` (documenting
+    the 4/27 release-notes leak per CONTRIBUTING.md:60–67); refresh the
+    ROADMAP strategic block (date + current version + phase).
+
+### PR B — Salvage daemon idle-death fix (E2E-gated)
+
+Rebase `fix/daemon-heartbeat-idle-reset` onto current `main` as a fresh
+branch. Touches `lib/daemon.js` + `lib/client.js` → **E2E daemon stage
+MANDATORY**. Maps to Todoist #9. Prepare PR; run E2E; **STOP before merge**.
+
+### PR C — Salvage fetch-images `--limit` fix (E2E-gated)
+
+Extract the `--limit` clamp + scroll from `fix/greentap-5-bugs-2026-04-25`
+onto a fresh branch off `main`. Touches `lib/commands.js` → **E2E image
+stage MANDATORY** (incl. multimodal `GREENTAP-E2E` legibility check). Maps
+to Todoist #6. Prepare PR; run E2E; **STOP before merge**.
+
+### QA pilot + fix cycle
+
+Run the new `docs/QA.md` runbook against greentap as a **pilot**, using
+parallel subagents for the offline matrix. Collect findings into
+`qa-reports/`. Run a fix cycle for the **most relevant** findings (red
+tests already in A1; plus any contract/error-path defects surfaced). Parser
+quote-reply misattribution (Todoist #5/#8) is investigated and fixed **only
+if** the pilot confirms a reproducible defect with an offline fixture —
+otherwise it's logged as a tracked follow-up (it touches `lib/parser.js` →
+its own E2E-gated PR, out of scope for this batch unless trivial).
+
+### Unbiased review
+
+Dispatch **parallel review subagents** with no stake in the work:
+`/review-code`, `/review-security`, and a release-process reviewer that
+checks the new QA/release docs for internal consistency and that the PII
+scanner ships no real tokens. Consolidate; address blockers before
+preparing release artifacts.
+
+## E2E reality + fallback
+
+E2E needs a live authenticated WhatsApp session + the `greentap-sandbox`
+group. Daemon is currently down; session may have expired (last E2E
+2026-04-27). **If E2E cannot run** (login expired → needs maintainer QR
+scan, which the agent cannot perform): PR B and PR C **do not merge** and
+v0.6.0 **falls back to v0.5.2 scope** (PR A only). This is surfaced, not
+worked around. PR A is unaffected (E2E-exempt).
+
+## What requires maintainer OK (gates)
+
+- **Every PR merge** — per-PR, per-session, explicit (CONTRIBUTING merge
+  protocol). No `--admin`.
+- **Pushing branches to the public remote** and **deleting remote branches**.
+- **Cutting the tag** + publishing the GitHub release.
+
+Local work (branch/stash cleanup that's local, file edits, tests, QA pilot,
+review) proceeds without a gate.
+
+## Testing
+
+- `npm test` must be green (precondition + after each change).
+- E2E (`GREENTAP_E2E=1 node greentap.js e2e`) for PR B/C lib changes.
+- QA pilot offline matrix as a new product-sanity layer.
+
+## Risks
+
+- **E2E unavailable** → v0.6.0 degrades to v0.5.2 (mitigation above).
+- **Pruning a not-actually-merged branch** → mitigated: each remote branch
+  verified against its merged PR (#15–#34) before deletion; salvage
+  branches explicitly excluded.
+- **PII scanner false sense of security** → it's a backstop, not a
+  replacement for the manual checklist; documented as such. Reviewer
+  subagent confirms it ships zero real tokens.
+- **Scope creep** → parser quote-reply work is explicitly deferred unless
+  trivially proven; this batch is stabilization + process, not a parser
+  overhaul.

--- a/greentap.js
+++ b/greentap.js
@@ -272,7 +272,15 @@ try {
       const fiIndexIdx = fiRaw.indexOf("--index");
       const fiLimitIdx = fiRaw.indexOf("--limit");
       const fiIndex = fiIndexIdx >= 0 ? parseInt(fiRaw[fiIndexIdx + 1], 10) : undefined;
-      const fiLimit = fiLimitIdx >= 0 ? parseInt(fiRaw[fiLimitIdx + 1], 10) : undefined;
+      let fiLimit = fiLimitIdx >= 0 ? parseInt(fiRaw[fiLimitIdx + 1], 10) : undefined;
+      // Bug 4: reject invalid --limit values at the CLI surface so the user
+      // sees a clear message instead of the silent slice(-NaN)/(- 0) full-fetch.
+      if (fiLimitIdx >= 0 && (!Number.isInteger(fiLimit) || fiLimit <= 0)) {
+        console.error(
+          `Invalid --limit ${JSON.stringify(fiRaw[fiLimitIdx + 1])}; must be a positive integer. Falling back to default.`
+        );
+        fiLimit = undefined;
+      }
       const fiScroll = fiRaw.includes("--scroll");
       const fiChat = fiRaw.filter((a, i) => {
         if (a === "--json" || a === "--limit" || a === "--index" || a === "--scroll") return false;

--- a/lib/client.js
+++ b/lib/client.js
@@ -21,7 +21,9 @@ import {
 } from "fs";
 import { detectLocale } from "./locale.js";
 
-const GREENTAP_DIR = join(homedir(), ".greentap");
+// GREENTAP_DIR honors an env override (matches lib/daemon.js) so tests can
+// isolate from the user's real ~/.greentap. Production never sets it.
+const GREENTAP_DIR = process.env.GREENTAP_DIR || join(homedir(), ".greentap");
 const PORT_FILE = join(GREENTAP_DIR, "daemon.port");
 const PID_FILE = join(GREENTAP_DIR, "daemon.pid");
 const LOCK_FILE = join(GREENTAP_DIR, "daemon.lock");

--- a/lib/client.js
+++ b/lib/client.js
@@ -17,6 +17,7 @@ import {
   writeFileSync,
   unlinkSync,
   readdirSync,
+  utimesSync,
 } from "fs";
 import { detectLocale } from "./locale.js";
 
@@ -24,8 +25,25 @@ const GREENTAP_DIR = join(homedir(), ".greentap");
 const PORT_FILE = join(GREENTAP_DIR, "daemon.port");
 const PID_FILE = join(GREENTAP_DIR, "daemon.pid");
 const LOCK_FILE = join(GREENTAP_DIR, "daemon.lock");
+const HEARTBEAT_FILE = join(GREENTAP_DIR, "daemon.heartbeat");
 const BROWSER_DATA_DIR = join(GREENTAP_DIR, "browser-data");
 const WA_URL = "https://web.whatsapp.com";
+
+function touchHeartbeat() {
+  // Daemon polls HEARTBEAT_FILE mtime to detect activity. Touching it on each
+  // successful connect resets the daemon's idle countdown — replaces the
+  // CDP-event hook in lib/daemon.js that never fired for connectOverCDP.
+  try {
+    const now = new Date();
+    utimesSync(HEARTBEAT_FILE, now, now);
+  } catch {
+    try {
+      writeFileSync(HEARTBEAT_FILE, "", { mode: 0o600 });
+    } catch {
+      // best effort — daemon will recreate on next poll if missing
+    }
+  }
+}
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const DAEMON_SCRIPT = join(__dirname, "daemon.js");
@@ -133,6 +151,7 @@ async function tryConnect(port) {
     await browser.close();
     throw new Error("No page found on daemon");
   }
+  touchHeartbeat();
   return { browser, page };
 }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -60,7 +60,12 @@ function readPort() {
 
 function readPid() {
   try {
-    return parseInt(readFileSync(PID_FILE, "utf8").trim(), 10);
+    const pid = parseInt(readFileSync(PID_FILE, "utf8").trim(), 10);
+    // Reject non-positive / NaN pids. A corrupted pid file containing "-1"
+    // would otherwise flow into process.kill(-1, ...) — a process-GROUP
+    // signal that fans out across the user's processes. greentap only ever
+    // writes a real positive child pid, so anything else is corruption.
+    return Number.isInteger(pid) && pid > 0 ? pid : null;
   } catch {
     return null;
   }
@@ -86,6 +91,9 @@ function cleanupStaleFiles() {
 }
 
 function isProcessAlive(pid) {
+  // Defense in depth: a non-positive pid makes process.kill signal a process
+  // GROUP (or every process, for -1). Never probe/​signal those.
+  if (!Number.isInteger(pid) || pid <= 0) return false;
   try {
     process.kill(pid, 0);
     return true;

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -789,6 +789,20 @@ export async function search(page, query, localeConfig) {
 }
 
 /**
+ * Clamp a user-supplied image limit to a positive integer, falling back to
+ * `fallback` for undefined / 0 / negative / non-integer (NaN) inputs. Guards
+ * the `slice(-limit)` degenerate case where `slice(-0)` / `slice(-NaN)` is
+ * `slice(0)` (the whole array) — the "fetch-images ignores --limit" bug.
+ *
+ * @param {unknown} limit
+ * @param {number} [fallback=20]
+ * @returns {number}
+ */
+export function clampImageLimit(limit, fallback = 20) {
+  return Number.isInteger(limit) && limit > 0 ? limit : fallback;
+}
+
+/**
  * Download recent images from a chat to local files.
  *
  * Navigates to <chatName>, parses the aria snapshot for image-kind messages,
@@ -827,13 +841,11 @@ export async function fetchImages(
   assertE2EAllowed(chatName);
   await navigateToChat(page, chatName, localeConfig, index);
 
-  // Clamp limit to a positive integer (Bug 4). The destructure default
-  // of 20 only fires when limit is undefined; explicit 0 / NaN / negative
-  // values would otherwise reach `slice(-limit)` where the language semantic
-  // `slice(-0)` (and `slice(-NaN)`) is `slice(0)` — i.e. the FULL array.
-  // That made `--limit 0` and any non-numeric --limit value silently fetch
-  // every visible image, which is exactly the "ignores --limit" report.
-  const safeLimit = Number.isInteger(limit) && limit > 0 ? limit : 20;
+  // Clamp limit to a positive integer (Bug 4). See clampImageLimit: explicit
+  // 0 / NaN / negative would otherwise reach `slice(-limit)` where
+  // `slice(-0)` / `slice(-NaN)` === `slice(0)` — i.e. the FULL array — so
+  // `--limit 0` and non-numeric values silently fetched every visible image.
+  const safeLimit = clampImageLimit(limit);
 
   // Optional scroll-back. We don't use the parsed messages from the scroll
   // iterations directly — the blob URLs we fetch below come from the current

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -251,6 +251,39 @@ export function dedupKey(msg) {
   return `${msg.sender}|${msg.time}|${(msg.text || "").slice(0, 50)}`;
 }
 
+/**
+ * Scroll the message panel to its bottom (most recent messages). Locale-
+ * agnostic: walks the DOM the same way findScrollContainer does, but
+ * doesn't store the data attribute — fire-and-forget.
+ *
+ * Used by fetchImages to recover from a stale scrolled-up state when
+ * navigateToChat's fast-path returns early.
+ *
+ * @param {import("playwright").Page} page
+ */
+async function scrollMessagePanelToBottom(page) {
+  await page.evaluate(() => {
+    const allRows = document.querySelectorAll('[role="row"]');
+    let msgRow = null;
+    for (const row of allRows) {
+      if (!row.closest('[role="grid"]')) {
+        msgRow = row;
+        break;
+      }
+    }
+    if (!msgRow) return;
+    let el = msgRow.parentElement;
+    while (el) {
+      const ov = getComputedStyle(el).overflowY;
+      if (ov === "auto" || ov === "scroll") break;
+      el = el.parentElement;
+    }
+    if (el) el.scrollTop = el.scrollHeight;
+  });
+  // Brief settle so virtualized rows render before the aria snapshot.
+  await new Promise((r) => setTimeout(r, 300));
+}
+
 async function findScrollContainer(page) {
   return page.evaluate(() => {
     // Find rows NOT inside a grid (message panel rows, not chat list rows)
@@ -794,6 +827,14 @@ export async function fetchImages(
   assertE2EAllowed(chatName);
   await navigateToChat(page, chatName, localeConfig, index);
 
+  // Clamp limit to a positive integer (Bug 4). The destructure default
+  // of 20 only fires when limit is undefined; explicit 0 / NaN / negative
+  // values would otherwise reach `slice(-limit)` where the language semantic
+  // `slice(-0)` (and `slice(-NaN)`) is `slice(0)` — i.e. the FULL array.
+  // That made `--limit 0` and any non-numeric --limit value silently fetch
+  // every visible image, which is exactly the "ignores --limit" report.
+  const safeLimit = Number.isInteger(limit) && limit > 0 ? limit : 20;
+
   // Optional scroll-back. We don't use the parsed messages from the scroll
   // iterations directly — the blob URLs we fetch below come from the current
   // DOM, and the final scrollAndCollect step lands the view back at the
@@ -804,13 +845,20 @@ export async function fetchImages(
     await scrollAndCollect(page, localeConfig);
   }
 
+  // Scroll the message panel to the bottom before parsing (Bug 5).
+  // navigateToChat's fast-path returns early when the chat is already open,
+  // so a chat left scrolled up by a previous `read --scroll` would otherwise
+  // expose old image rows to fetchImages — stale results that contribute to
+  // the "ignores --limit" perception. Idempotent after scrollAndCollect.
+  await scrollMessagePanelToBottom(page);
+
   // 1. Parse aria to identify image messages + their order within the row area.
   const aria = await page.locator(":root").ariaSnapshot();
   // Pass `now` so any relative-date separator above the image rows resolves
   // deterministically against the read moment.
   const allMsgs = parseMessages(aria, { localeConfig, now: new Date() });
   const allImages = allMsgs.filter((m) => m.kind === "image");
-  const images = allImages.slice(-limit);
+  const images = allImages.slice(-safeLimit);
   if (images.length === 0) {
     if (stderr) {
       console.error(

--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -22,6 +22,8 @@ import {
   renameSync,
   unlinkSync,
   chmodSync,
+  utimesSync,
+  statSync,
 } from "fs";
 
 // GREENTAP_DIR and GREENTAP_CDP_PORT env vars exist for test isolation only.
@@ -30,6 +32,7 @@ const GREENTAP_DIR = process.env.GREENTAP_DIR || join(homedir(), ".greentap");
 const USER_DATA_DIR = join(GREENTAP_DIR, "browser-data");
 const PORT_FILE = join(GREENTAP_DIR, "daemon.port");
 const PID_FILE = join(GREENTAP_DIR, "daemon.pid");
+const HEARTBEAT_FILE = join(GREENTAP_DIR, "daemon.heartbeat");
 const WA_URL = "https://web.whatsapp.com";
 const CDP_PORT_DEFAULT = 19222;
 const CDP_PORT = (() => {
@@ -39,10 +42,22 @@ const CDP_PORT = (() => {
   if (!Number.isFinite(n) || n <= 0 || n > 65535) return CDP_PORT_DEFAULT;
   return n;
 })();
-const IDLE_TIMEOUT_MS = 15 * 60 * 1000;
+// GREENTAP_IDLE_TIMEOUT_MS / GREENTAP_HEARTBEAT_INTERVAL_MS exist for tests only.
+const IDLE_TIMEOUT_MS = (() => {
+  const raw = process.env.GREENTAP_IDLE_TIMEOUT_MS;
+  if (!raw) return 15 * 60 * 1000;
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : 15 * 60 * 1000;
+})();
+const HEARTBEAT_INTERVAL_MS = (() => {
+  const raw = process.env.GREENTAP_HEARTBEAT_INTERVAL_MS;
+  if (!raw) return 60 * 1000;
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : 60 * 1000;
+})();
 
 let context = null;
-let idleTimer = null;
+let heartbeatTicker = null;
 
 function writeAtomic(filePath, content) {
   const tmp = filePath + ".tmp";
@@ -51,8 +66,8 @@ function writeAtomic(filePath, content) {
 }
 
 function cleanupFiles() {
-  // Daemon only cleans port + PID files. Lock file is owned by the client.
-  for (const f of [PORT_FILE, PID_FILE]) {
+  // Daemon only cleans port + PID + heartbeat files. Lock file is owned by the client.
+  for (const f of [PORT_FILE, PID_FILE, HEARTBEAT_FILE]) {
     try {
       unlinkSync(f);
     } catch {
@@ -61,13 +76,45 @@ function cleanupFiles() {
   }
 }
 
-function resetIdleTimer() {
-  if (idleTimer) clearTimeout(idleTimer);
-  idleTimer = setTimeout(shutdown, IDLE_TIMEOUT_MS);
+function touchHeartbeat() {
+  // Update heartbeat mtime to "now". Create the file if missing.
+  try {
+    const now = new Date();
+    utimesSync(HEARTBEAT_FILE, now, now);
+  } catch {
+    try {
+      writeFileSync(HEARTBEAT_FILE, "", { mode: 0o600 });
+    } catch {
+      // best effort
+    }
+  }
+}
+
+function checkHeartbeat() {
+  // Idle = no client touched the heartbeat file recently. The CDP-event-based
+  // reset in the original implementation was a no-op (Target.attachedToTarget
+  // never fires for external connectOverCDP clients on a session that only
+  // called setDiscoverTargets), so the daemon died after exactly
+  // IDLE_TIMEOUT_MS regardless of activity. Filesystem heartbeat is
+  // protocol-agnostic and observable from tests.
+  let mtimeMs;
+  try {
+    mtimeMs = statSync(HEARTBEAT_FILE).mtimeMs;
+  } catch {
+    // Heartbeat missing — recreate at "now" so we don't shut down on a
+    // transient disk hiccup, but log so it's diagnosable.
+    console.error("[daemon] heartbeat file missing; recreating");
+    touchHeartbeat();
+    return;
+  }
+  const ageMs = Date.now() - mtimeMs;
+  if (ageMs >= IDLE_TIMEOUT_MS) {
+    shutdown();
+  }
 }
 
 async function shutdown() {
-  if (idleTimer) clearTimeout(idleTimer);
+  if (heartbeatTicker) clearInterval(heartbeatTicker);
   try {
     if (context) await context.close();
   } catch {
@@ -88,6 +135,12 @@ async function main() {
   // start (15-30s) because the port file appeared only after launch.
   writeAtomic(PORT_FILE, String(CDP_PORT));
   writeAtomic(PID_FILE, String(process.pid));
+  touchHeartbeat();
+
+  // Start the idle-poll ticker BEFORE launching Chrome. This way the daemon
+  // still self-exits on idle even if Chrome cold-start hangs (it normally
+  // takes 15-30s, which is fine; a true hang would otherwise leave a zombie).
+  heartbeatTicker = setInterval(checkHeartbeat, HEARTBEAT_INTERVAL_MS);
 
   // Launch persistent context with CDP.
   // Uses Playwright's bundled Chromium (no `channel: "chrome"`) to avoid
@@ -140,19 +193,6 @@ async function main() {
     // Client will handle recovery on connect
   }
 
-  // Monitor CDP connections via context CDP session
-  // Note: context.browser() returns null for launchPersistentContext,
-  // so we use the context-level CDP session instead.
-  try {
-    const cdpSession = await context.newCDPSession(page);
-    // Use page-level session to detect target attach/detach
-    await cdpSession.send("Target.setDiscoverTargets", { discover: true });
-    cdpSession.on("Target.attachedToTarget", () => resetIdleTimer());
-    cdpSession.on("Target.detachedFromTarget", () => resetIdleTimer());
-  } catch {
-    // Fallback: just use the idle timer without CDP events
-  }
-
   // Handle browser crash/disconnect via context close event
   context.on("close", () => {
     cleanupFiles();
@@ -163,8 +203,10 @@ async function main() {
   process.on("SIGTERM", shutdown);
   process.on("SIGINT", shutdown);
 
-  // Start idle timer
-  resetIdleTimer();
+  // Idle detection ticker was started before launchPersistentContext so the
+  // daemon self-exits even on a Chrome hang. Clients touch HEARTBEAT_FILE on
+  // each connect (see lib/client.js); daemon shuts down when the last touch
+  // is older than IDLE_TIMEOUT_MS.
 }
 
 main().catch((err) => {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -395,10 +395,13 @@ function extractQuoteBlock(rowBody) {
     // Match any of the container shapes WA uses for quote-cards:
     //   `generic:` (no label)
     //   `button "...":` / `link "...":` (with a locale-specific aria label)
-    // The strict 2-text-children check below filters out non-quote
-    // buttons (image attachments, reactions) and non-quote links.
+    //   `gridcell:` and bare `button:` (no label) — observed in some
+    //     snapshots where WA omits the aria label on the quote container.
+    // The strict 2-text-children check below (plus the HH:MM/date decorative
+    // guard) filters out non-quote buttons (image attachments, reactions),
+    // non-quote links, and decorative date+time gridcells.
     const containerMatch = lines[i].match(
-      /^( +)- (?:generic|button "[^"]*"|link "[^"]*"):\s*$/,
+      /^( +)- (?:generic|gridcell|button|link|button "[^"]*"|link "[^"]*"):\s*$/,
     );
     if (!containerMatch) continue;
     const baseIndent = containerMatch[1].length;
@@ -425,15 +428,22 @@ function extractQuoteBlock(rowBody) {
     if (!scannedAnyChild) continue;
 
     // Quote block signature: exactly two `text:` direct children. This
-    // strictness is what makes broadening to button/link containers
+    // strictness is what makes broadening to button/link/gridcell containers
     // safe — image-attachment buttons have ≥2 `img:` children, reaction
     // buttons have one img, none have exactly two text children.
     if (children.length === 2 && children.every((c) => c.startsWith("text: "))) {
+      const first = children[0].slice("text: ".length).trim();
+      const second = children[1].slice("text: ".length).trim();
+      // Decorative-container guard: a 2-text container whose second child is
+      // a bare time (HH:MM) or whose children are a date+time pair is NOT a
+      // quote-card (e.g. a forwarded-message header or a date/time chip).
+      // A real quote-card's second child is the quoted message text.
+      const isTime = (s) => /^\d{1,2}:\d{2}$/.test(s);
+      const isDate = (s) => /^\d{1,2}[./-]\d{1,2}[./-]\d{2,4}$/.test(s);
+      if (isTime(second) || isDate(first)) continue;
       return {
-        quotedSender: stripProbableMatchPrefix(
-          stripTildePrefix(children[0].slice("text: ".length).trim()),
-        ),
-        quotedText: children[1].slice("text: ".length).trim(),
+        quotedSender: stripProbableMatchPrefix(stripTildePrefix(first)),
+        quotedText: second,
       };
     }
   }
@@ -502,6 +512,14 @@ export function parseMessages(ariaText, options = {}) {
 
   const messages = [];
   let currentSender = "";
+  // Freshness flag for the fresh-sender rule (Bug 1). Set true when a sender
+  // button is parsed for the upcoming row; reset to false after a row
+  // consumes it. When a row carries a quote block but its own sender was NOT
+  // freshly confirmed (no sender button since the previous row, no own-icon,
+  // and the row label does not start with the carried sender), we must not
+  // attribute the reply to the stale carried sender (often the quoted
+  // person) — emit UNKNOWN_SENDER instead.
+  let senderConfirmedForRow = false;
   let currentDate = null;
 
   // Auto-detect sender button prefix from first sender button encountered
@@ -528,6 +546,7 @@ export function parseMessages(ariaText, options = {}) {
       const senderBtn = line.match(prefixRegex);
       if (senderBtn) {
         currentSender = stripProbableMatchPrefix(stripTildePrefix(senderBtn[1]));
+        senderConfirmedForRow = true;
         continue;
       }
     } else {
@@ -563,6 +582,7 @@ export function parseMessages(ariaText, options = {}) {
           // ("Forse" / "Maybe" / "Peut-être" / …) that WA inserts when its
           // phone-to-contact heuristic is uncertain.
           currentSender = stripProbableMatchPrefix(stripTildePrefix(name));
+          senderConfirmedForRow = true;
           continue;
         }
       }
@@ -680,7 +700,27 @@ export function parseMessages(ariaText, options = {}) {
       } else if (body.startsWith(quotedText)) {
         body = body.slice(quotedText.length).trim();
       }
+
+      // Fresh-sender rule (Bug 1): a quote-reply row whose own sender was NOT
+      // freshly confirmed is dangerous to attribute — `currentSender` may be
+      // stale and is frequently the QUOTED person (their name appears in the
+      // quote-card just above the reply bubble). Only trust the carried
+      // sender when it was set by a sender button for this row, the message
+      // is own, or the row label visibly starts with the carried sender
+      // (group-continuation cue). Otherwise refuse to guess and emit
+      // UNKNOWN_SENDER instead of confidently mis-attributing the reply.
+      if (!isOwn && !senderConfirmedForRow) {
+        const labelConfirms =
+          currentSender && rowLabel.startsWith(currentSender);
+        if (!labelConfirms) {
+          sender = UNKNOWN_SENDER;
+        }
+      }
     }
+
+    // The freshness signal is single-row scoped: a sender button confirms
+    // only the next row. Reset it now that this row has consumed it.
+    senderConfirmedForRow = false;
 
     // Detect image attachments in this row (structural, locale-independent).
     // A row may contain BOTH images and text caption — emit one "image" entry

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "greentap",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "CLI driver for WhatsApp Web via Playwright",
   "main": "greentap.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
   },
   "scripts": {
     "test": "node --test 'test/**/*.test.js'",
+    "pii": "./scripts/pii-scan.sh --worktree",
+    "install-hooks": "./scripts/install-hooks.sh",
     "postinstall": "playwright install chromium"
   },
   "type": "module",

--- a/scripts/greentap-pii-tokens.example
+++ b/scripts/greentap-pii-tokens.example
@@ -1,0 +1,28 @@
+# greentap PII token list — EXAMPLE / TEMPLATE
+#
+# Copy this to a GITIGNORED location the scanner reads (in priority order):
+#   1. path in $GREENTAP_PII_TOKENS
+#   2. .git/greentap-pii-tokens      (inside .git, never committed)
+#   3. ~/.greentap/pii-tokens
+#
+#   cp scripts/greentap-pii-tokens.example .git/greentap-pii-tokens
+#   # then edit in your real identity tokens
+#
+# NEVER commit the filled-in file. NEVER put real tokens in this .example
+# file or any other tracked file (CONTRIBUTING.md:25).
+#
+# Format: one literal forbidden substring per line, case-insensitive.
+# Blank lines and lines starting with '#' are ignored. Tokens are matched
+# as fixed strings (regex chars are auto-escaped), so write them plainly.
+#
+# Structural patterns (phone shapes, /Users/<user>/ paths, task-tracker
+# URLs/issue-keys) are already built into pii-scan.sh — do NOT add those
+# here. This file is ONLY for identity specifics the scanner can't guess:
+#
+#   <maintainer-first-name>
+#   <maintainer-last-name>
+#   <maintainer-nickname>
+#   <maintainer-username>
+#   maintainer@<personal-email-domain>
+#   <personal-email-domain>
+#   <real-phone-prefix-not-in-synthetic-allowlist>

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -14,6 +14,12 @@ set -euo pipefail
 ROOT="$(git rev-parse --show-toplevel)"
 HOOK="$ROOT/.git/hooks/pre-commit"
 
+# Don't silently clobber a pre-existing, non-greentap hook — back it up first.
+if [ -e "$HOOK" ] && ! grep -q "greentap pre-commit hook" "$HOOK" 2>/dev/null; then
+  cp "$HOOK" "$HOOK.bak"
+  echo "Backed up existing pre-commit hook -> $HOOK.bak"
+fi
+
 cat > "$HOOK" <<'HOOK_EOF'
 #!/usr/bin/env bash
 # greentap pre-commit hook (installed by scripts/install-hooks.sh).

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# install-hooks.sh — install greentap's local git hooks (opt-in, no deps).
+#
+# Installs a pre-commit hook that runs scripts/pii-scan.sh --staged, so a
+# commit carrying potential PII is blocked before it ever lands. This is a
+# backstop for the manual discipline in CONTRIBUTING.md, not a replacement.
+#
+# Idempotent. Run once per clone:  ./scripts/install-hooks.sh
+# Bypass a single commit (use sparingly):  git commit --no-verify
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+HOOK="$ROOT/.git/hooks/pre-commit"
+
+cat > "$HOOK" <<'HOOK_EOF'
+#!/usr/bin/env bash
+# greentap pre-commit hook (installed by scripts/install-hooks.sh).
+# Blocks commits that contain potential PII. Bypass: git commit --no-verify
+set -euo pipefail
+ROOT="$(git rev-parse --show-toplevel)"
+if [ -x "$ROOT/scripts/pii-scan.sh" ]; then
+  "$ROOT/scripts/pii-scan.sh" --staged
+else
+  echo "pre-commit: scripts/pii-scan.sh missing or not executable — skipping PII scan." >&2
+fi
+HOOK_EOF
+
+chmod +x "$HOOK"
+echo "Installed pre-commit hook -> $HOOK"
+echo "Tip: create .git/greentap-pii-tokens from scripts/greentap-pii-tokens.example"
+echo "     to enable identity-token (name/email) scanning in addition to structural."

--- a/scripts/pii-scan.sh
+++ b/scripts/pii-scan.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+#
+# pii-scan.sh — backstop PII scanner for the PUBLIC greentap repo.
+#
+# This is a SAFETY NET, not a replacement for the manual pre-merge grep
+# discipline documented in CONTRIBUTING.md ("PII patterns"). It exists
+# because the 2026-04-27 leak happened with manual-grep-only defense.
+#
+# Design constraint (CONTRIBUTING.md:25): this committed script must NOT
+# contain any real PII token. It ships only STRUCTURAL patterns (phone
+# shapes, /Users/ paths, task-tracker URLs) plus the documented SYNTHETIC
+# allowlist. Identity-specific tokens (maintainer name / email / private
+# domain) are read at runtime from a GITIGNORED local file, never from a
+# tracked file. Resolution order:
+#   1. $GREENTAP_PII_TOKENS (path)
+#   2. .git/greentap-pii-tokens
+#   3. ~/.greentap/pii-tokens
+# Each non-blank, non-'#' line is a literal case-insensitive forbidden
+# substring. See scripts/greentap-pii-tokens.example for the format.
+#
+# Modes:
+#   --staged              scan staged (index) content        [default]
+#   --range <A>..<B>      scan files changed + commit messages in A..B
+#   --worktree            scan all tracked files in the working tree
+#   --show                print the offending line (default: redacted)
+#
+# Exit: 0 = clean, 1 = potential PII found, 2 = usage error.
+
+set -uo pipefail
+
+MODE="staged"
+RANGE=""
+SHOW=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --staged)   MODE="staged" ;;
+    --worktree) MODE="worktree" ;;
+    --range)    MODE="range"; RANGE="${2:-}"; shift ;;
+    --range=*)  MODE="range"; RANGE="${1#--range=}" ;;
+    --messages) MODE="messages"; RANGE="${2:-}"; shift ;;
+    --show)     SHOW=1 ;;
+    -h|--help)
+      sed -n '2,40p' "$0"; exit 0 ;;
+    *) echo "pii-scan: unknown arg '$1'" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+cd "$(git rev-parse --show-toplevel)" || { echo "pii-scan: not a git repo" >&2; exit 2; }
+
+# --- Structural patterns (public-safe; no real PII) ----------------------
+# Phone: international-looking sequences. Synthetic doc numbers excluded below.
+PHONE='\+[0-9][0-9()  .\-]{8,}[0-9]'
+# Absolute macOS home paths — none should ever appear in a public repo.
+USERPATH='/Users/[A-Za-z0-9._-]+/'
+# Task-tracker URLs / issue keys.
+TRACKER='(app\.todoist\.com|todoist\.com/(app|showTask|task)|linear\.app/|[a-z0-9-]+\.atlassian\.net|/browse/[A-Z][A-Z0-9]+-[0-9]+)'
+# Synthetic phone allowlist — these are NOT violations:
+#  - the documented doc numbers (CONTRIBUTING.md): +39 555…, +1 555…, +39 02 0000…
+#  - the established fixture convention: an all-zeros tail (>=3 "00" groups),
+#    e.g. +33 6 00 00 00 01 — unambiguously a placeholder, never a real number.
+SYNTH_PHONE='\+39[ ]?555|\+1[ ]?555|\+39[ ]?02[ ]?0000|\+39[ ]?555[ ]?010|00[ ]?00[ ]?00'
+
+STRUCT="(${PHONE})|(${USERPATH})|(${TRACKER})"
+
+# --- Identity token file (gitignored) ------------------------------------
+TOKENS_FILE=""
+for cand in "${GREENTAP_PII_TOKENS:-}" ".git/greentap-pii-tokens" "$HOME/.greentap/pii-tokens"; do
+  [ -n "$cand" ] && [ -f "$cand" ] && { TOKENS_FILE="$cand"; break; }
+done
+
+TOKEN_PAT=""
+if [ -n "$TOKENS_FILE" ]; then
+  # Build an alternation of escaped literal tokens for grep -iE.
+  TOKEN_PAT="$(grep -vE '^\s*(#|$)' "$TOKENS_FILE" \
+    | sed -E 's/[][(){}.^$*+?|\\]/\\&/g' \
+    | paste -sd'|' -)"
+else
+  echo "pii-scan: NOTE — no identity token file found; running STRUCTURAL-only." >&2
+  echo "pii-scan:        (set \$GREENTAP_PII_TOKENS or create .git/greentap-pii-tokens" >&2
+  echo "pii-scan:         from scripts/greentap-pii-tokens.example to enable name/email checks)" >&2
+fi
+
+# Hits are recorded to a temp file, not a shell var: scan_text runs on the
+# right side of a pipe (a subshell), so a var counter would not survive.
+HITFILE="$(mktemp)"
+trap 'rm -f "$HITFILE"' EXIT
+
+emit() { # file  lineno  rule  line
+  printf '.\n' >> "$HITFILE"
+  if [ "$SHOW" = "1" ]; then
+    printf '  %s:%s [%s] %s\n' "$1" "$2" "$3" "$4" >&2
+  else
+    printf '  %s:%s [%s] (match redacted — rerun with --show locally to view)\n' "$1" "$2" "$3" >&2
+  fi
+}
+
+scan_text() { # label  <stdin: text with line numbers "N:content">
+  local label="$1" line lineno content
+  while IFS= read -r line; do
+    lineno="${line%%:*}"
+    content="${line#*:}"
+    # Structural — but drop synthetic phone matches first.
+    if printf '%s' "$content" | grep -qE "$STRUCT"; then
+      # If the only structural hit is a synthetic phone, skip it.
+      local stripped
+      stripped="$(printf '%s' "$content" | grep -oE "$PHONE" | grep -vE "$SYNTH_PHONE" || true)"
+      if printf '%s' "$content" | grep -qE "(${USERPATH})|(${TRACKER})" || [ -n "$stripped" ]; then
+        emit "$label" "$lineno" "structural" "$content"
+      fi
+    fi
+    # Identity tokens.
+    if [ -n "$TOKEN_PAT" ] && printf '%s' "$content" | grep -qiE "$TOKEN_PAT"; then
+      emit "$label" "$lineno" "identity-token" "$content"
+    fi
+  done
+}
+
+is_text_blob() { # ref:path  -> 0 if text
+  ! git show "$1" 2>/dev/null | grep -qclP '\x00' 2>/dev/null
+}
+
+scan_file_at() { # ref(":" for index or "SHA:")  path
+  local ref="$1" path="$2" blob="$1$2"
+  # Skip binary.
+  if git show "$blob" 2>/dev/null | grep -qIl . 2>/dev/null; then :; else return 0; fi
+  git show "$blob" 2>/dev/null | grep -nE "$STRUCT" 2>/dev/null | scan_text "$path"
+  if [ -n "$TOKEN_PAT" ]; then
+    git show "$blob" 2>/dev/null | grep -niE "$TOKEN_PAT" 2>/dev/null | scan_text "$path"
+  fi
+}
+
+case "$MODE" in
+  staged)
+    while IFS= read -r f; do
+      [ -z "$f" ] && continue
+      scan_file_at ":" "$f"
+    done < <(git diff --cached --name-only --diff-filter=ACM)
+    ;;
+  worktree)
+    while IFS= read -r f; do
+      [ -z "$f" ] && continue
+      [ -f "$f" ] || continue
+      if grep -qIl . "$f" 2>/dev/null; then
+        grep -nE "$STRUCT" "$f" 2>/dev/null | scan_text "$f"
+        [ -n "$TOKEN_PAT" ] && grep -niE "$TOKEN_PAT" "$f" 2>/dev/null | scan_text "$f"
+      fi
+    done < <(git ls-files)
+    ;;
+  range)
+    [ -z "$RANGE" ] && { echo "pii-scan: --range needs A..B" >&2; exit 2; }
+    B="${RANGE##*..}"
+    while IFS= read -r f; do
+      [ -z "$f" ] && continue
+      scan_file_at "$B:" "$f"
+    done < <(git diff --name-only --diff-filter=ACM "$RANGE")
+    # Commit messages in range.
+    git log "$RANGE" --format='%H%x09%s%x09%b' 2>/dev/null \
+      | grep -nE "$STRUCT" | scan_text "commit-message"
+    if [ -n "$TOKEN_PAT" ]; then
+      git log "$RANGE" --format='%H%x09%s%x09%b' 2>/dev/null \
+        | grep -niE "$TOKEN_PAT" | scan_text "commit-message"
+    fi
+    ;;
+  messages)
+    [ -z "$RANGE" ] && { echo "pii-scan: --messages needs A..B" >&2; exit 2; }
+    git log "$RANGE" --format='%H%x09%s%x09%b' 2>/dev/null \
+      | grep -nE "$STRUCT" | scan_text "commit-message"
+    if [ -n "$TOKEN_PAT" ]; then
+      git log "$RANGE" --format='%H%x09%s%x09%b' 2>/dev/null \
+        | grep -niE "$TOKEN_PAT" | scan_text "commit-message"
+    fi
+    ;;
+esac
+
+HITS="$(wc -l < "$HITFILE" | tr -d ' ')"
+if [ "${HITS:-0}" -gt 0 ]; then
+  echo "pii-scan: FAIL — $HITS potential PII match(es). This is a public repo; remove before committing/pushing." >&2
+  echo "pii-scan: structural matches can be false positives (synthetic numbers are allowlisted); review each." >&2
+  exit 1
+fi
+echo "pii-scan: clean (${MODE})."
+exit 0

--- a/scripts/pii-scan.sh
+++ b/scripts/pii-scan.sh
@@ -60,6 +60,9 @@ TRACKER='(app\.todoist\.com|todoist\.com/(app|showTask|task)|linear\.app/|[a-z0-
 #  - the documented doc numbers (CONTRIBUTING.md): +39 555…, +1 555…, +39 02 0000…
 #  - the established fixture convention: an all-zeros tail (>=3 "00" groups),
 #    e.g. +33 6 00 00 00 01 — unambiguously a placeholder, never a real number.
+# Deliberate false-negative: a REAL number that happens to contain an internal
+# "00 00 00" run is suppressed too. Accepted trade-off — such numbers are rare
+# and the identity-token list (below) is the backstop for known real numbers.
 SYNTH_PHONE='\+39[ ]?555|\+1[ ]?555|\+39[ ]?02[ ]?0000|\+39[ ]?555[ ]?010|00[ ]?00[ ]?00'
 
 STRUCT="(${PHONE})|(${USERPATH})|(${TRACKER})"
@@ -117,13 +120,9 @@ scan_text() { # label  <stdin: text with line numbers "N:content">
   done
 }
 
-is_text_blob() { # ref:path  -> 0 if text
-  ! git show "$1" 2>/dev/null | grep -qclP '\x00' 2>/dev/null
-}
-
 scan_file_at() { # ref(":" for index or "SHA:")  path
-  local ref="$1" path="$2" blob="$1$2"
-  # Skip binary.
+  local path="$2" blob="$1$2"
+  # Skip binary (grep -I treats a NUL-containing blob as binary).
   if git show "$blob" 2>/dev/null | grep -qIl . 2>/dev/null; then :; else return 0; fi
   git show "$blob" 2>/dev/null | grep -nE "$STRUCT" 2>/dev/null | scan_text "$path"
   if [ -n "$TOKEN_PAT" ]; then
@@ -150,6 +149,11 @@ case "$MODE" in
     ;;
   range)
     [ -z "$RANGE" ] && { echo "pii-scan: --range needs A..B" >&2; exit 2; }
+    # Validate the range resolves — an unresolvable ref or a swallowed flag
+    # (e.g. `--range --show`) must FAIL loudly, never silently report "clean".
+    if ! git rev-list "$RANGE" >/dev/null 2>&1; then
+      echo "pii-scan: invalid range '$RANGE' (does not resolve)" >&2; exit 2
+    fi
     B="${RANGE##*..}"
     while IFS= read -r f; do
       [ -z "$f" ] && continue

--- a/test/daemon-control.test.js
+++ b/test/daemon-control.test.js
@@ -90,6 +90,25 @@ test("daemonStatus: dead pid → not running, and stale files are cleaned", asyn
   assert.ok(!existsSync(PORT_FILE), "stale port file should be removed");
 });
 
+test("daemonStatus: a negative pid file is treated as not-running (no process-group probe)", () => {
+  clearDaemonFiles();
+  writeDaemonFiles(-1, 19987); // corrupted pid; -1 would mean "process group"
+  assert.deepStrictEqual(daemonStatus(), { running: false });
+});
+
+test("daemonStatus: a non-numeric pid file is treated as not-running", () => {
+  clearDaemonFiles();
+  writeFileSync(PID_FILE, "not-a-pid");
+  writeFileSync(PORT_FILE, "19987");
+  assert.deepStrictEqual(daemonStatus(), { running: false });
+});
+
+test("stopDaemon: never signals a process group for a negative pid", () => {
+  clearDaemonFiles();
+  writeDaemonFiles(-1, 19987);
+  assert.strictEqual(stopDaemon(), false); // must NOT reach process.kill(-1, SIGTERM)
+});
+
 test("stopDaemon: returns false when no daemon is running", () => {
   clearDaemonFiles();
   assert.strictEqual(stopDaemon(), false);

--- a/test/daemon-control.test.js
+++ b/test/daemon-control.test.js
@@ -1,0 +1,124 @@
+import { test, before, after } from "node:test";
+import assert from "node:assert";
+import { mkdtempSync, rmSync, writeFileSync, existsSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { spawn } from "child_process";
+
+// Isolate from the real ~/.greentap BEFORE importing the client module: the
+// GREENTAP_DIR const is read at import time, so the env must be set first.
+const TMP = mkdtempSync(join(tmpdir(), "greentap-ctl-"));
+process.env.GREENTAP_DIR = TMP;
+const { daemonStatus, stopDaemon } = await import("../lib/client.js");
+
+const PID_FILE = join(TMP, "daemon.pid");
+const PORT_FILE = join(TMP, "daemon.port");
+
+/** A harmless long-lived child whose PID we can probe and SIGTERM. */
+function spawnDummy() {
+  return spawn(process.execPath, ["-e", "setInterval(() => {}, 1e9)"], {
+    stdio: "ignore",
+  });
+}
+
+/** Spawn + kill + await exit → a PID that is guaranteed dead. */
+async function deadPid() {
+  const c = spawnDummy();
+  const pid = c.pid;
+  await new Promise((resolve) => {
+    c.on("exit", resolve);
+    c.kill("SIGKILL");
+  });
+  return pid;
+}
+
+function writeDaemonFiles(pid, port) {
+  writeFileSync(PID_FILE, String(pid));
+  if (port !== undefined) writeFileSync(PORT_FILE, String(port));
+}
+
+function clearDaemonFiles() {
+  for (const f of [PID_FILE, PORT_FILE]) {
+    try {
+      rmSync(f, { force: true });
+    } catch {
+      // ignore
+    }
+  }
+}
+
+before(() => clearDaemonFiles());
+after(() => {
+  try {
+    rmSync(TMP, { recursive: true, force: true });
+  } catch {
+    // best effort
+  }
+});
+
+test("daemonStatus: not running when no pid/port files exist", () => {
+  clearDaemonFiles();
+  assert.deepStrictEqual(daemonStatus(), { running: false });
+});
+
+test("daemonStatus: not running when pid file present but port missing", () => {
+  clearDaemonFiles();
+  writeFileSync(PID_FILE, String(process.pid)); // alive pid, but no port file
+  assert.deepStrictEqual(daemonStatus(), { running: false });
+});
+
+test("daemonStatus: running for a live pid + port", () => {
+  clearDaemonFiles();
+  const child = spawnDummy();
+  try {
+    writeDaemonFiles(child.pid, 19987);
+    const status = daemonStatus();
+    assert.strictEqual(status.running, true);
+    assert.strictEqual(status.pid, child.pid);
+    assert.strictEqual(status.port, 19987);
+  } finally {
+    child.kill("SIGKILL");
+  }
+});
+
+test("daemonStatus: dead pid → not running, and stale files are cleaned", async () => {
+  clearDaemonFiles();
+  const pid = await deadPid();
+  writeDaemonFiles(pid, 19987);
+  assert.deepStrictEqual(daemonStatus(), { running: false });
+  assert.ok(!existsSync(PID_FILE), "stale pid file should be removed");
+  assert.ok(!existsSync(PORT_FILE), "stale port file should be removed");
+});
+
+test("stopDaemon: returns false when no daemon is running", () => {
+  clearDaemonFiles();
+  assert.strictEqual(stopDaemon(), false);
+});
+
+test("stopDaemon: dead pid → false, and stale files are cleaned", async () => {
+  clearDaemonFiles();
+  const pid = await deadPid();
+  writeDaemonFiles(pid, 19987);
+  assert.strictEqual(stopDaemon(), false);
+  assert.ok(!existsSync(PID_FILE), "stale pid file should be removed");
+});
+
+test("stopDaemon: live pid → true and the process receives SIGTERM", async () => {
+  clearDaemonFiles();
+  const child = spawnDummy();
+  const exited = new Promise((resolve) => child.on("exit", (_code, signal) => resolve(signal)));
+  writeDaemonFiles(child.pid, 19987);
+
+  assert.strictEqual(stopDaemon(), true);
+
+  // The dummy installs no SIGTERM handler, so default disposition terminates it.
+  const signal = await Promise.race([
+    exited,
+    new Promise((resolve) => setTimeout(() => resolve("TIMEOUT"), 3000)),
+  ]);
+  if (signal === "TIMEOUT") {
+    child.kill("SIGKILL");
+    assert.fail("stopDaemon should have terminated the live daemon process via SIGTERM");
+  }
+  assert.strictEqual(signal, "SIGTERM", "process should be terminated by SIGTERM");
+});

--- a/test/daemon.test.js
+++ b/test/daemon.test.js
@@ -93,6 +93,107 @@ test("daemon source writes port file before launchPersistentContext", () => {
   );
 });
 
+test("daemon idle reset is heartbeat-file based, not CDP-event based", () => {
+  // Regression guard for the bug Neko surfaced 2026-05-09: the original
+  // implementation listened on Target.attachedToTarget / detachedFromTarget on
+  // a CDP session that only called Target.setDiscoverTargets. Those events
+  // never fire for external connectOverCDP clients, so the idle timer never
+  // reset — daemon died after exactly 15min regardless of activity. Replaced
+  // with a heartbeat file that the client touches on every connect (see
+  // lib/client.js touchHeartbeat()).
+  const sourceNoComments = DAEMON_SOURCE
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/\/\/[^\n]*/g, "");
+
+  assert.strictEqual(
+    /Target\.(attachedToTarget|detachedFromTarget|setDiscoverTargets)/.test(
+      sourceNoComments,
+    ),
+    false,
+    "daemon.js must not rely on CDP Target.* events for idle reset (they never fire for connectOverCDP clients)",
+  );
+  assert.ok(
+    /HEARTBEAT_FILE/.test(sourceNoComments),
+    "daemon.js must use a heartbeat file for idle detection",
+  );
+  assert.ok(
+    /setInterval\(\s*checkHeartbeat/.test(sourceNoComments),
+    "daemon.js must poll the heartbeat file via setInterval",
+  );
+});
+
+test("daemon shuts down when heartbeat is older than IDLE_TIMEOUT_MS", async () => {
+  // End-to-end check: spawn daemon with a very short timeout, never touch
+  // the heartbeat, and verify the daemon exits on its own. This proves the
+  // idle path actually fires (the original implementation would have stayed
+  // up because the broken CDP listener never reset the timer either way —
+  // but with the fix, "no heartbeat ever" still leads to shutdown).
+  const tmpDir = mkdtempSync(join(tmpdir(), "greentap-test-"));
+  const pidFile = join(tmpDir, "daemon.pid");
+  const testPort = 19334;
+
+  const child = fork(DAEMON_SCRIPT, [], {
+    detached: true,
+    stdio: "ignore",
+    env: {
+      ...process.env,
+      GREENTAP_DIR: tmpDir,
+      GREENTAP_CDP_PORT: String(testPort),
+      GREENTAP_IDLE_TIMEOUT_MS: "500",
+      GREENTAP_HEARTBEAT_INTERVAL_MS: "100",
+    },
+  });
+
+  try {
+    // Wait for PID file to appear (daemon started).
+    const startDeadline = Date.now() + 3000;
+    while (Date.now() < startDeadline) {
+      await new Promise((r) => setTimeout(r, 50));
+      if (existsSync(pidFile)) break;
+    }
+    assert.ok(existsSync(pidFile), "daemon should have started");
+
+    // Wait for the daemon to self-exit (idle timeout + a few poll cycles).
+    // We don't touch the heartbeat, so the daemon should shut down once
+    // checkHeartbeat sees the initial-touch mtime age exceed 500ms. Allow
+    // a generous deadline because Chrome launch is in flight and shutdown
+    // has to clean up port/pid files before the process exits.
+    const exitDeadline = Date.now() + 15000;
+    let exited = false;
+    while (Date.now() < exitDeadline) {
+      await new Promise((r) => setTimeout(r, 100));
+      try {
+        process.kill(child.pid, 0);
+      } catch {
+        exited = true;
+        break;
+      }
+    }
+    assert.ok(exited, "daemon should self-exit after idle timeout elapses");
+    assert.ok(
+      !existsSync(pidFile),
+      "daemon should clean up pid file on idle shutdown",
+    );
+  } finally {
+    try {
+      process.kill(child.pid, "SIGKILL");
+    } catch {
+      // already gone
+    }
+    try {
+      process.kill(-child.pid, "SIGKILL");
+    } catch {
+      // no group
+    }
+    await new Promise((r) => setTimeout(r, 200));
+    try {
+      rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      // best effort
+    }
+  }
+});
+
 test("daemon does not pin channel:'chrome' — uses bundled Chromium (#14)", () => {
   // Static check: the `channel: "chrome"` option must be absent from
   // launchPersistentContext. Using bundled Chromium isolates greentap's

--- a/test/fetch-images.test.js
+++ b/test/fetch-images.test.js
@@ -1,6 +1,35 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { slugifyChat, imageFilename } from "../lib/commands.js";
+import { slugifyChat, imageFilename, clampImageLimit } from "../lib/commands.js";
+
+describe("clampImageLimit (Bug 4 — --limit guard)", () => {
+  it("passes through a valid positive integer", () => {
+    assert.equal(clampImageLimit(5), 5);
+    assert.equal(clampImageLimit(1), 1);
+  });
+
+  it("falls back to default (20) for undefined", () => {
+    assert.equal(clampImageLimit(undefined), 20);
+  });
+
+  it("falls back for 0 — the slice(-0) === slice(0) full-array trap", () => {
+    assert.equal(clampImageLimit(0), 20);
+  });
+
+  it("falls back for negative values", () => {
+    assert.equal(clampImageLimit(-5), 20);
+  });
+
+  it("falls back for NaN / non-integer", () => {
+    assert.equal(clampImageLimit(NaN), 20);
+    assert.equal(clampImageLimit(2.5), 20);
+    assert.equal(clampImageLimit("abc"), 20);
+  });
+
+  it("honours a custom fallback", () => {
+    assert.equal(clampImageLimit(0, 10), 10);
+  });
+});
 
 describe("slugifyChat", () => {
   it("lowercases and replaces spaces with hyphens", () => {

--- a/test/fixtures/quoted-reply-gridcell.snapshot.txt
+++ b/test/fixtures/quoted-reply-gridcell.snapshot.txt
@@ -1,0 +1,33 @@
+- document:
+  - banner:
+    - button "Dettagli profilo":
+      - img
+    - button "Famiglia Rossi clicca qui per info gruppo"
+    - button "Videochiamata di gruppo": Chiama
+    - button "Cerca"
+    - button "Menu"
+  - text: Oggi
+  - button "Apri dettagli chat di Roberto Marini":
+    - img
+  - row "Roberto Marini Roberto Marini Lavinia Vitale 14:25":
+    - text: Roberto Marini
+    - gridcell:
+      - text: Roberto Marini
+      - text: Lavinia Vitale
+    - text: 14:25
+  - button "Apri dettagli chat di Daniele Bottazzini":
+    - img
+  - row "Daniele Bottazzini Roberto Marini Lavinia Vitale Esatto, non prenderle 14:30":
+    - text: Daniele Bottazzini
+    - button:
+      - text: Roberto Marini
+      - text: Lavinia Vitale
+    - text: Esatto, non prenderle
+    - text: 14:30
+  - contentinfo:
+    - button "Allega"
+    - button "Emoji, GIF, Sticker"
+    - textbox "Scrivi al gruppo Famiglia Rossi":
+      - paragraph
+    - button "Messaggio vocale":
+      - button "Messaggio vocale"

--- a/test/navigate.test.js
+++ b/test/navigate.test.js
@@ -300,13 +300,13 @@ describe("navigateToChat: --index disambiguation in search fallback", () => {
 });
 
 describe("navigateToChat: partial-match suggestions", () => {
-  // Two chats whose names share a "Foot" prefix — Neko's "GROUP_X"
-  // + "Foot." repro pattern.
+  // Two chats whose names share a "Foot" prefix ("Football" + "Foot.") —
+  // Neko's partial-match repro pattern. Both contain the query "Foot".
   const TWO_FOOT_CHATS = `- grid "Lista delle chat":
-    - 'row "GROUP_X 14:00 Bonjour"':
-      - 'gridcell "GROUP_X 14:00 Bonjour"':
+    - 'row "Football 14:00 Bonjour"':
+      - 'gridcell "Football 14:00 Bonjour"':
         - img
-        - gridcell "GROUP_X 14:00"
+        - gridcell "Football 14:00"
         - text: Bonjour
         - gridcell
     - 'row "Foot. 09:00 Salut"':
@@ -334,7 +334,7 @@ describe("navigateToChat: partial-match suggestions", () => {
           /Did you mean one of/.test(err.message),
           `expected partial-match suggestion, got: ${err.message}`,
         );
-        assert.ok(err.message.includes("GROUP_X"), "expected first candidate listed");
+        assert.ok(err.message.includes("Football"), "expected first candidate listed");
         assert.ok(err.message.includes("Foot."), "expected second candidate listed");
         assert.ok(err.message.includes("--index"), "expected --index hint");
         return true;
@@ -354,7 +354,7 @@ describe("navigateToChat: partial-match suggestions", () => {
           /Did you mean one of/.test(err.message),
           `expected partial-match suggestion, got: ${err.message}`,
         );
-        assert.ok(err.message.includes("GROUP_X"));
+        assert.ok(err.message.includes("Football"));
         assert.ok(err.message.includes("Foot."));
         return true;
       },

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -822,3 +822,134 @@ describe("parsePollMessages", () => {
     assert.deepEqual(parsePollMessages(""), []);
   });
 });
+
+describe("parseMessages — quoted-reply gridcell/button containers (Bug 1/2/3)", () => {
+  it("extracts quote block from gridcell-shaped container (Bug 2)", () => {
+    // WhatsApp Web's aria does not always render quote-cards as `generic:`.
+    // Observed shapes include `gridcell:`, `button:`, and `link:`. PR #27's
+    // generic-only restriction caused body / quoted_sender / quoted_text to
+    // be silently empty for these rows. Verify the broadened detector
+    // recognizes a 2-text gridcell (Roberto's row in this fixture).
+    const aria = loadFixture("quoted-reply-gridcell.snapshot.txt");
+    const messages = parseMessages(aria);
+    const roberto = messages.find((m) => m.sender === "Roberto Marini");
+    assert.ok(roberto, `expected Roberto's row, got: ${JSON.stringify(messages, null, 2)}`);
+    assert.equal(roberto.quoted_sender, "Roberto Marini");
+    assert.equal(roberto.quoted_text, "Lavinia Vitale");
+  });
+
+  it("extracts quote block from button-shaped container (Bug 2)", () => {
+    // Same fixture, second row uses a `button:` container around the quote.
+    const aria = loadFixture("quoted-reply-gridcell.snapshot.txt");
+    const messages = parseMessages(aria);
+    const reply = messages.find((m) => m.sender === "Daniele Bottazzini");
+    assert.ok(reply, `expected Daniele's reply, got: ${JSON.stringify(messages, null, 2)}`);
+    assert.equal(reply.quoted_sender, "Roberto Marini");
+    assert.equal(reply.quoted_text, "Lavinia Vitale");
+    assert.equal(reply.body, "Esatto, non prenderle");
+  });
+
+  it("does NOT attribute a quote-reply to the quoted person (Bug 1)", () => {
+    // Estevan replies to Lavinia. The quote block contains Lavinia's name.
+    // Pre-fix, a stale carry-over could cause the parser to attribute
+    // Estevan's bubble to Lavinia (since her name appears in the row body).
+    // With the fresh-sender rule + quote detection, attribution must stay
+    // on Estevan.
+    const aria = `- document:
+  - banner:
+    - button "Dettagli profilo":
+      - img
+  - text: Oggi
+  - button "Apri dettagli chat di Lavinia":
+    - img
+  - row "Lavinia Sì certo nessun problema 11:00":
+    - text: Lavinia Sì certo nessun problema 11:00
+  - button "Apri dettagli chat di Estevan":
+    - img
+  - row "Estevan Lavinia Sì certo nessun problema Perfetto, allora ci vediamo lì 11:08":
+    - text: Estevan
+    - gridcell:
+      - text: Lavinia
+      - text: Sì certo nessun problema
+    - text: Perfetto, allora ci vediamo lì
+    - text: 11:08
+  - contentinfo:
+    - textbox "Scrivi"`;
+    const messages = parseMessages(aria);
+    const estevanReply = messages.find((m) => m.text.includes("Perfetto"));
+    assert.ok(estevanReply, `expected Estevan's reply, got: ${JSON.stringify(messages, null, 2)}`);
+    assert.equal(estevanReply.sender, "Estevan",
+      "quote-reply must be attributed to the bubble's own sender, not the quoted person");
+    assert.equal(estevanReply.quoted_sender, "Lavinia");
+    assert.equal(estevanReply.quoted_text, "Sì certo nessun problema");
+    assert.equal(estevanReply.body, "Perfetto, allora ci vediamo lì");
+  });
+
+  it("emits (unknown) for a quote-reply whose sender button is missing AND label doesn't confirm (Bug 1 safe path)", () => {
+    // Worst case: Estevan's button got scrolled off, leaving currentSender
+    // stale (Lavinia from earlier). The row body still has the quote with
+    // Lavinia's name. Bug 3 hardening kicks in: row label doesn't start
+    // with "Lavinia" → fall to UNKNOWN_SENDER. The agent gets a clear
+    // "I don't know" instead of a confident wrong answer.
+    const aria = `- document:
+  - banner:
+    - button "Dettagli profilo":
+      - img
+  - text: Oggi
+  - button "Apri dettagli chat di Lavinia":
+    - img
+  - row "Lavinia Sì certo 11:00":
+    - text: Lavinia Sì certo 11:00
+  - row "Estevan Lavinia Sì certo Perfetto 11:08":
+    - text: Estevan
+    - gridcell:
+      - text: Lavinia
+      - text: Sì certo
+    - text: Perfetto
+    - text: 11:08
+  - contentinfo:
+    - textbox "Scrivi"`;
+    const messages = parseMessages(aria);
+    const reply = messages.find((m) => m.text.includes("Perfetto"));
+    assert.ok(reply, `expected reply, got: ${JSON.stringify(messages, null, 2)}`);
+    assert.equal(reply.sender, "(unknown)",
+      "missing-button quote-reply must NOT inherit Lavinia's sender — emit (unknown)");
+    assert.equal(reply.quoted_sender, "Lavinia");
+    assert.equal(reply.quoted_text, "Sì certo");
+  });
+
+  it("rejects 2-text decorative containers where the second child is HH:MM (Bug 2 safety)", () => {
+    // Decorative date+time gridcell — must NOT be treated as a quote-card.
+    // Without the HH:MM safety, this would emit quoted_text="14:25" which
+    // is nonsense.
+    const aria = `- document:
+  - banner:
+    - button "Dettagli profilo":
+      - img
+  - text: Oggi
+  - button "Apri dettagli chat di Roberto Marini":
+    - img
+  - row "Roberto Marini hello 14:25":
+    - text: Roberto Marini hello
+    - gridcell:
+      - text: 14/03/2026
+      - text: 14:25
+    - text: 14:25
+  - contentinfo:
+    - textbox "Scrivi"`;
+    const messages = parseMessages(aria);
+    assert.ok(messages.length > 0);
+    assert.equal(messages[0].quoted_sender, null,
+      "decorative date+time gridcell must NOT be detected as a quote-card");
+    assert.equal(messages[0].quoted_text, null);
+  });
+
+  // NOTE: a 6th case from the source branch — "orphan row right after a quote
+  // block falls back to (unknown)" — is DEFERRED. It contradicts the existing
+  // shipped contract test (parseMessages — sender always populated:
+  // "orphan row ... inherits sender from previous message"), which expects the
+  // same fixture row to inherit the previous sender. Flipping that to
+  // (unknown) is a behavioral-contract change to non-quote orphan rows and is
+  // a separate maintainer decision — tracked in docs/known-leaks.md /
+  // qa-reports, not bundled into this quote-reply fix.
+});


### PR DESCRIPTION
# v0.6.0 — release-prep (review + approve, do NOT merge without explicit OK)

Two-stage release per `docs/RELEASE.md`: this is the **Stage 1 prep PR** (version bump + QA verdict). Tagging is Stage 2, after merge, gated separately.

## What ships (functional)

**Bug fixes**
- **Daemon no longer dies every 15 min.** The idle-timeout never reset (CDP listener never fired for `connectOverCDP`), so every cron/agent call after a gap paid a 15–30s cold-start. Now reset via a heartbeat file the client touches on connect.
- **`fetch-images --limit` is no longer silently ignored.** `--limit 0`/negative/non-numeric used to `slice(-0)` → dump *every* image. Now validated at the CLI + clamped internally.
- **Quote-replies attributed to the right person.** On the `gridcell`/bare-`button` quote-card shape (when the replier's name is off-screen), the parser used to label the message with the *quoted* author. Now it extracts the quote correctly and emits `(unknown)` rather than a confident wrong sender. (`#27` had only fixed the common shapes.)
- **`main` is green again.** A PII-sanitized test fixture (`GROUP_X`) no longer matched its own assertion; v0.5.0/v0.5.1 were tagged red. Fixed.

**Release / safety infrastructure (omnisess-parity)**
- **Automated PII guard** — `scripts/pii-scan.sh` + opt-in pre-commit hook. Ships zero real tokens (structural patterns + synthetic allowlist; identity tokens load from a gitignored file). Closes the manual-grep gap behind the 2026-04-27 leak.
- **Two-stage release runbook** (`docs/RELEASE.md`) + real `make` targets (`test`/`pii`/`release-check`/`tag`) replacing the dead Swift Makefile + release-notes privacy template.
- **Agentic QA runbook** (`docs/QA.md`) + `docs/known-leaks.md` register.
- **Public-tag PII remediation:** `pre-swift-removal` (pre-anonymization fixtures, live on origin) deleted; all non-semver tags pruned.
- Housekeeping: stale branches/stashes pruned, ROADMAP refreshed, maintainer's unmerged CONTRIBUTING notes salvaged.

## QA evidence

- **Tests:** 199 pass / 0 fail (was 174/2-fail on `main`). New coverage: `clampImageLimit`, daemon stop/start (status + SIGTERM + corrupted-pid guards), 5 quote-reply regression tests.
- **E2E:** `GREENTAP_E2E=1 … e2e` → exit 0, all 4 stages ran (preflight/text/image/link); image stage multimodally verified (`GREENTAP-E2E` legible). Re-run after each `lib/` change.
- **release-check:** PASS (clean tree + version-sync + tests + PII).
- **Reviews:** two unbiased reviewers (code + security) → **no blockers**; a focused QA pass (parser + daemon) → **no blockers**. All advisories addressed or documented below.

## Deferred / documented (your call, not blocking)

- **Bug 3 (orphan-after-quote → `(unknown)`):** conflicts with an existing shipped contract (non-quote orphan inheritance). Left for an explicit decision — not bundled.
- **A1 (parser):** a label-less, image-less 2-text container could be misread as a quote (spurious `quoted_*`; *sender stays correct*). Unobserved shape; documented.
- **A3/A4:** microsecond pid-reuse window in a test; `--limit 3.5`→`3` (cosmetic). Documented, no change.
- **Fixture first-names** (`docs/known-leaks.md`): pre-existing, document-don't-rewrite.

## Merge protocol

Per `CONTRIBUTING.md`: **do not merge without an explicit per-PR "merge it"** this session; **no `--admin`**; tagging is a separate Stage-2 step requiring its own OK.
