### PR TITLE
chore(qa): add agent-governed visual QA gate (screenshot↔JSON) to release process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,9 @@ summary_stats.txt
 *_msgs.json
 *_stats.txt
 
-# QA reports (may reference real chat data) + local PII token list
+# QA reports + visual-QA screenshots (contain real chat data) + local PII tokens
 qa-reports/
+qa-visual-out/
 greentap-pii-tokens
 !scripts/greentap-pii-tokens.example
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -215,6 +215,12 @@ Before running `git tag`, **every** item must be green:
 7. **PII grep on the diff `<prev-tag>..HEAD` is clean.** Tracked
    files only — `git ls-files` × `git show <SHA>:<file>`. Same
    forbidden-token list.
+8. **Visual QA gate is green** (`VISUAL-QA: pass` or `pass with
+   N notes`). Run the agent-governed screenshot↔JSON semantic check
+   on a representative group per `TESTING.md` — it catches attribution
+   drift (wrong `sender`, dropped quote cards, lost messages) that
+   `npm test` and `e2e` pass straight through. A `VISUAL-QA: fail`
+   blocks the tag until fixed (with a fake-data fixture).
 
 ### Tag + release
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,137 @@
+# Testing greentap
+
+greentap has three test layers, each closing a different gap:
+
+| Layer | Command | Catches |
+|-------|---------|---------|
+| **Unit** | `npm test` | parser/logic regressions against recorded fixtures |
+| **E2E** | `GREENTAP_E2E=1 node greentap.js e2e` | real round-trip break (send/read/image/link) against the sandbox |
+| **Visual QA gate** | agent-governed (this doc) | **semantic** drift — does the extracted JSON faithfully represent what the UI actually shows? |
+
+`npm test` and `e2e` prove the code *runs* and *round-trips*. Neither proves the
+JSON is *semantically correct*: a parser can confidently return a clean-looking
+message whose `sender` is the wrong person, whose quoted reply was silently
+dropped, or whose body absorbed the quoted author's name. Those failures only
+surface when you compare the JSON against the pixels. That comparison is the
+visual QA gate.
+
+This gate was added after a 2026-06-20 QA run found three sender-attribution
+bugs (phone number leaking into `sender`, quote-reply cards not parsed, own
+messages mislabeled) that **all unit tests and e2e passed straight through** —
+because the fixtures encoded the same wrong assumptions the parser made. Only a
+screenshot-vs-JSON comparison caught them.
+
+---
+
+## When to run the visual QA gate
+
+- **Mandatory** on every release-prep, before `git tag` (it is item 8 of the
+  CONTRIBUTING.md pre-tag checklist).
+- **Strongly recommended** for any PR touching `lib/parser.js` or
+  `lib/commands.js` — the fixtures can lie; the pixels can't.
+- Optional otherwise.
+
+Pick a **representative chat**: a busy **group** with quote-replies, unsaved
+contacts (so phone-number/`~` handling is exercised), emoji, and at least one of
+your own messages. A 1:1 chat is not sufficient — most attribution bugs live in
+groups.
+
+---
+
+## Data / PII policy (strict — public repo)
+
+The screenshot and the JSON contain **real names, phone numbers, and message
+content**. Therefore:
+
+- The screenshot output dir (`qa-visual-out/`, or a `/tmp` scratch dir) is
+  **never committed** and never attached to a PR.
+- The **QA report contains structural findings only**: counts, field names,
+  bug classes, severities, and message **timestamps** as identifiers. Never
+  reproduce names, phone numbers, or verbatim message text (a 2–3 word
+  paraphrase to identify a message is fine).
+- Any new fixture distilled from a finding uses **fake data only** (see
+  CONTRIBUTING.md → PII patterns; fake names like Roberto Marini / Elena Conti,
+  fake numbers like `+39 555 0100 200`).
+
+---
+
+## Procedure
+
+```bash
+# 0. scratch dir (gitignored / /tmp)
+mkdir -p /tmp/gtqa
+
+# 1. extract the JSON (this ALSO opens the chat in the daemon's browser)
+node greentap.js read "<Representative Group>" --json > /tmp/gtqa/read.json
+
+# 2. screenshot the now-open conversation pane (high-DPI + legibility bands)
+node scripts/qa-visual.mjs --out /tmp/gtqa
+#    → writes main-2x.png and band-1.png … band-3.png
+
+# 3. hand both to the QA agent (prompt below); it returns the report
+```
+
+Then dispatch a subagent with the **comparator prompt** below, pointing it at
+`/tmp/gtqa/band-*.png` (+ `main-2x.png`) and `/tmp/gtqa/read.json`. Run it
+**unbiased** — do not tell it what you expect to find.
+
+---
+
+## The comparator agent prompt
+
+> You are an independent QA auditor. Judge only from evidence; assume nothing is
+> correct or broken. Verify whether a CLI's extracted JSON is a **semantically
+> correct** representation of what a WhatsApp chat shows on screen.
+>
+> Inputs (local, in-session only — they contain private data; in your report do
+> NOT reproduce names, phone numbers, or long verbatim text; identify messages
+> by `time` + a short paraphrase; write the report only as your returned text,
+> never to a file):
+> - Screenshots: `<out>/main-2x.png` and bands `<out>/band-1.png …`
+> - Extracted JSON: `<out>/read.json` (array of `{kind, sender, text, time,
+>   timestamp, quoted_sender, quoted_text, body, links}`)
+>
+> For each JSON message (match by `time` + content), check:
+> 1. **Sender** exactly matches the author shown in the UI. Flag any `sender`
+>    carrying extra tokens — a phone number, a `~`/"Forse"/"Maybe" prefix, or
+>    the *quoted* person's name — or simply the wrong person. Own messages must
+>    be `"You"`, not a localized self-label.
+> 2. **Quote cards**: where the UI shows a quote-reply card (nested box with an
+>    original author + text), the JSON must capture it in `quoted_sender` /
+>    `quoted_text` — not leave them null with the quoted content bled into
+>    `text`/`body`.
+> 3. **Body fidelity**: `body` matches the actual message (ignoring emoji
+>    rendering); flag bleed, truncation, or loss.
+> 4. **Completeness**: any message on screen missing from JSON, or vice-versa.
+>
+> Output: a findings table (`time | issue class | UI vs JSON`), then a list of
+> distinct bug classes with affected-message counts and severity. State plainly
+> if everything is correct.
+
+---
+
+## Report format + status rubric
+
+Write the agent's findings into a report (kept local — `qa-reports/` is
+gitignored, mirroring omnisess). End with one status line:
+
+| Outcome | Status line | Action |
+|---------|-------------|--------|
+| No semantic defects | `VISUAL-QA: pass` | proceed to tag once human review OK |
+| Cosmetic/edge issues only | `VISUAL-QA: pass with N notes` | maintainer decides whether to block |
+| Any wrong `sender`, dropped quote, or lost/extra message | `VISUAL-QA: fail — <class>` | **do NOT tag**; fix + re-run |
+
+A `fail` blocks the release. The fix should land as a normal PR **with a
+fake-data fixture** that reproduces the defect, so the regression is captured at
+the unit layer too — that is how the 2026-06-20 bugs were closed.
+
+---
+
+## Scope notes
+
+- macOS only (the daemon drives system Chrome; `sips` band-slicing is macOS).
+- `scripts/qa-visual.mjs` is a dev/QA helper, not part of the shipped CLI — it
+  lives in `scripts/` so it carries no e2e obligation and stays reversible.
+- Future: promote the comparator into a `/qa-release` skill once the prompt
+  stabilizes; add a first-class `greentap screenshot` command if the CDP helper
+  proves too fragile.

--- a/scripts/qa-visual.mjs
+++ b/scripts/qa-visual.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+/**
+ * qa-visual.mjs — capture a high-DPI screenshot of the conversation pane for
+ * the agent-governed visual QA gate (see TESTING.md).
+ *
+ * It connects to the running greentap daemon over CDP and screenshots whatever
+ * chat is currently open. The intended flow (per TESTING.md) is:
+ *
+ *   1. node greentap.js read "<chat>" --json > /tmp/gtqa/read.json   # opens the chat
+ *   2. node scripts/qa-visual.mjs --out /tmp/gtqa                      # screenshots it
+ *   3. an agent compares the screenshot bands against read.json
+ *
+ * This is a DEV/QA helper, not part of the shipped CLI surface — it lives in
+ * scripts/ (not lib/) precisely so it carries no e2e obligation and stays a
+ * reversible tool. It reads only; it never sends or mutates the chat.
+ *
+ * Output (under --out, default ./qa-visual-out):
+ *   main-2x.png    full conversation pane at deviceScaleFactor 2
+ *   band-1.png …   horizontal slices for legibility (macOS only, via `sips`)
+ *
+ * PII: the screenshot contains real chat content. Treat --out as scratch,
+ * keep it out of git (it is not under a tracked path), and never attach raw
+ * screenshots to a public PR — the QA report carries structural findings only.
+ *
+ * Flags:
+ *   --out <dir>       output directory (default ./qa-visual-out)
+ *   --port <n>        CDP port (default: ~/.greentap/daemon.port, else 19222)
+ *   --bands <n>       number of legibility slices to cut (default 3, 0 = none)
+ *   --scale <n>       deviceScaleFactor (default 2)
+ */
+import { chromium } from "playwright";
+import { join } from "path";
+import { homedir } from "os";
+import { readFileSync, mkdirSync, existsSync } from "fs";
+import { execFileSync } from "child_process";
+
+function arg(name, fallback) {
+  const i = process.argv.indexOf(`--${name}`);
+  return i >= 0 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+}
+
+function resolvePort() {
+  const explicit = arg("port", null);
+  if (explicit) return parseInt(explicit, 10);
+  try {
+    const p = readFileSync(join(homedir(), ".greentap", "daemon.port"), "utf8").trim();
+    if (p) return parseInt(p, 10);
+  } catch {
+    // fall through to default
+  }
+  return 19222;
+}
+
+const outDir = arg("out", "./qa-visual-out");
+const port = resolvePort();
+const scale = parseInt(arg("scale", "2"), 10);
+const bands = parseInt(arg("bands", "3"), 10);
+
+mkdirSync(outDir, { recursive: true });
+
+const browser = await chromium.connectOverCDP(`http://127.0.0.1:${port}`, { timeout: 5000 });
+const ctx = browser.contexts()[0];
+if (!ctx) {
+  console.error("qa-visual: no browser context on the daemon. Run `greentap status`.");
+  process.exit(1);
+}
+const page = ctx.pages()[0];
+if (!page) {
+  console.error("qa-visual: no page on the daemon.");
+  process.exit(1);
+}
+
+const client = await ctx.newCDPSession(page);
+await client.send("Emulation.setDeviceMetricsOverride", {
+  width: 1100,
+  height: 1300,
+  deviceScaleFactor: scale,
+  mobile: false,
+});
+await page.waitForTimeout(600);
+
+const mainPath = join(outDir, "main-2x.png");
+const main = page.locator("#main");
+if (!(await main.count())) {
+  console.error(
+    "qa-visual: no #main conversation pane — is a chat open? " +
+      "Run `greentap read \"<chat>\" --json` first.",
+  );
+  await client.send("Emulation.clearDeviceMetricsOverride").catch(() => {});
+  await browser.close();
+  process.exit(1);
+}
+await main.first().screenshot({ path: mainPath });
+console.log(`wrote ${mainPath}`);
+
+// Optional legibility slices via macOS `sips` (best-effort; skipped elsewhere).
+if (bands > 0) {
+  try {
+    const dims = execFileSync("sips", ["-g", "pixelWidth", "-g", "pixelHeight", mainPath], {
+      encoding: "utf8",
+    });
+    const w = parseInt(/pixelWidth: (\d+)/.exec(dims)?.[1], 10);
+    const h = parseInt(/pixelHeight: (\d+)/.exec(dims)?.[1], 10);
+    if (w && h) {
+      const bandH = Math.floor(h / bands) + 60;
+      for (let i = 0; i < bands; i++) {
+        const offset = Math.max(0, Math.floor((i * h) / bands) - 30);
+        const p = join(outDir, `band-${i + 1}.png`);
+        execFileSync("sips", [
+          "-c", String(Math.min(bandH, h - offset)), String(w),
+          mainPath, "--cropOffset", String(offset), "0", "--out", p,
+        ], { stdio: "ignore" });
+        console.log(`wrote ${p}`);
+      }
+    }
+  } catch {
+    console.log("qa-visual: band slicing skipped (sips unavailable — macOS only).");
+  }
+}
+
+await client.send("Emulation.clearDeviceMetricsOverride").catch(() => {});
+await browser.close();
+if (existsSync(mainPath)) process.exit(0);


### PR DESCRIPTION
## Summary

Brings **omnisess-style agentic QA** to greentap's release process, and codifies the **visual screenshot↔JSON semantic check** that surfaced the PR #36 attribution bugs into a repeatable, agent-governed gate.

### Why

`npm test` and `e2e` prove the code *runs* and *round-trips* — neither proves the JSON is **semantically correct**. A parser can confidently return a message with the wrong `sender`, a silently-dropped quote card, or a body that absorbed the quoted author's name. The 2026-06-20 sender-attribution bugs (PR #36) **passed all unit tests and e2e** because the fixtures encoded the same wrong assumptions the parser made. Only a screenshot-vs-JSON comparison caught them. This gate makes that comparison a standing release step.

### Comparison with omnisess

| | omnisess | greentap (before) | greentap (this PR) |
|---|---|---|---|
| Code correctness | `make check` + 100% cover | `npm test` | `npm test` |
| Round-trip | — | `e2e` (mandatory) | `e2e` (mandatory) |
| **Semantic/product QA** | **agentic gate (`TESTING.md` + `qa-reports/`)** | ❌ none | ✅ **visual QA gate** |
| Pre-tag checklist | release.md | CONTRIBUTING (7 items) | CONTRIBUTING (8 items) |

### What's added

- **`TESTING.md`** — the QA methodology: the three test layers, when to run, strict **PII policy** (reports carry structural findings only — no names/numbers/verbatim text), the procedure, a **reusable unbiased comparator-agent prompt**, and a report format + status rubric (`VISUAL-QA: pass / pass-with-notes / fail`).
- **`scripts/qa-visual.mjs`** — a **read-only** CDP helper that screenshots the open conversation pane at 2× and slices legibility bands. Lives in `scripts/` (not `lib/`) so it carries **no e2e obligation** and stays reversible.
- **`CONTRIBUTING.md`** — visual QA gate added as **item 8** of the mandatory pre-tag checklist; a `VISUAL-QA: fail` blocks the tag.
- **`.gitignore`** — `qa-visual-out/` ignored (screenshots contain real chat data).

### Verification

- ✅ 199 unit tests pass (no code touched).
- ✅ Helper verified end-to-end against the sandbox (`main-2x.png` + 3 bands produced).
- This gate was dry-run during the PR #36 investigation: the comparator subagent independently reproduced all three attribution bugs from screenshot↔JSON alone.

### Notes
- macOS only (daemon drives system Chrome; `sips` band-slicing is macOS).
- Future: promote the comparator into a `/qa-release` skill; add a first-class `greentap screenshot` command if the CDP helper proves fragile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)