### PR TITLE
fix(parser): preserve emoji in message content (text + body)

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -426,6 +426,50 @@ function stripSenderPrefix(joined, sender) {
 }
 
 /**
+ * Collect a message row's content tokens in document order, interleaving text
+ * with emoji.
+ *
+ * Emoji are rendered as `img "<glyph>"` nodes (the accessible name IS the emoji
+ * character), so a text-node-only pass silently drops them — a message that is
+ * just "👍" reads as empty, and "Mi piace 😅 molto" loses the emoji. We restore
+ * them by walking the row body line-by-line and emitting emoji imgs alongside
+ * text nodes, preserving order.
+ *
+ * Which emoji count as message content is the crux: only DIRECT-CHILD imgs
+ * (4-space indent — direct children of the row) are the message's own emoji.
+ * Nested imgs are NOT content: contact avatars, reaction emoji (inside a
+ * `button "reazione …"`), and quoted-message emoji (inside the quote card,
+ * already carried by quoted_text) all live deeper and must be excluded.
+ * Emoji are distinguished from system icon ids (`wds-ic-*`, `msg-*`, `ic-*`,
+ * `wa-*`) structurally: an emoji glyph contains a non-ASCII codepoint; icon ids
+ * are pure ASCII.
+ *
+ * @param {string[]} bodyLines - The row's body lines, original indentation kept.
+ * @param {boolean} directTextOnly - true → only 4-space text nodes (for `body`,
+ *   excludes nested quote-bleed text); false → text at any depth (for the
+ *   legacy `text` field that retains the bleed). Emoji are always direct-only.
+ * @returns {string[]} ordered content tokens (time nodes removed)
+ */
+function collectRowContent(bodyLines, directTextOnly) {
+  const out = [];
+  for (const line of bodyLines) {
+    const tm = line.match(/^( *)- text: (.+)$/);
+    if (tm) {
+      if (directTextOnly && tm[1].length !== 4) continue;
+      if (/^\d{1,2}:\d{2}$/.test(tm[2].trim())) continue; // standalone time
+      const v = tm[2].replace(/\s+\d{1,2}:\d{2}$/, "").trim(); // trailing time
+      if (v) out.push(v);
+      continue;
+    }
+    const im = line.match(/^( *)- img "(.+?)"$/);
+    if (im && im[1].length === 4 && /[^\x00-\x7F]/.test(im[2])) {
+      out.push(im[2]); // direct-child emoji glyph
+    }
+  }
+  return out;
+}
+
+/**
  * Detect a quoted-reply block inside a row body.
  *
  * WhatsApp Web renders a quote-reply as a sibling container at the same
@@ -714,27 +758,22 @@ export function parseMessages(ariaText, options = {}) {
         rowBody,
       );
 
-    // `text` (legacy contract): joined from ALL text nodes at any depth —
-    // retains the quoted bleed for backward compatibility with existing
-    // callers. Time-only nodes filtered out; a trailing time stripped.
-    const allContentNodes = textNodes
-      .filter((t) => !/^\d{1,2}:\d{2}$/.test(t))
-      .map((t) => t.replace(/\s+\d{1,2}:\d{2}$/, "").trim())
-      .filter(Boolean);
+    // `text` (legacy contract): text at ANY depth (retains the quoted bleed for
+    // backward compatibility) interleaved with the row's own direct-child emoji.
+    const allContentNodes = collectRowContent(bodyLines, false);
 
-    // `body` (clean reply): joined from DIRECT-CHILD text nodes only (4-space
-    // indent). Text nested inside a quote container (the quoted sender + the
-    // quoted text, when the quote is rendered as nested text nodes) lives at
-    // 6+ space indent and is excluded — so the reply body never inherits the
-    // quoted bleed. For non-quote rows the two node sets are identical, so
+    // `body` (clean reply): DIRECT-CHILD text only (4-space) — text nested in a
+    // quote container (quoted sender/text) lives deeper and is excluded, so the
+    // reply body never inherits the quoted bleed — interleaved with the row's
+    // own direct-child emoji. For non-quote rows the text sets are identical, so
     // `body === text` (a contract guaranteed by tests).
+    const directContentNodes = collectRowContent(bodyLines, true);
+
+    // Raw direct-child text nodes (sender label included, no time filter) — used
+    // only to confirm the carried sender on continuation quote rows below.
     const directTextNodesRaw = bodyLines
       .filter((l) => /^    - text: /.test(l))
       .map((l) => l.replace(/^ {4}- text: /, "").trim());
-    const directContentNodes = directTextNodesRaw
-      .filter((t) => !/^\d{1,2}:\d{2}$/.test(t))
-      .map((t) => t.replace(/\s+\d{1,2}:\d{2}$/, "").trim())
-      .filter(Boolean);
 
     let sender;
     if (isOwn) {

--- a/test/fixtures/emoji-messages.snapshot.txt
+++ b/test/fixtures/emoji-messages.snapshot.txt
@@ -1,0 +1,39 @@
+- document:
+  - banner:
+    - button "Dettagli profilo":
+      - img
+    - button "Aperitivo Test clicca qui per info gruppo"
+    - button "Cerca"
+    - button "Menu"
+  - text: Oggi
+  - button "Apri dettagli chat di Roberto Marini":
+    - img
+  - row "Roberto Marini Mi piace tanto 😅 e anche questo 😂 10:00":
+    - text: Roberto Marini
+    - text: Mi piace tanto
+    - img "😅"
+    - text: e anche questo
+    - img "😂"
+    - text: 10:00
+  - row "Roberto Marini 👍 👍 😅 10:01 reazione ❤️. Visualizza reazioni":
+    - text: Roberto Marini
+    - img "👍"
+    - img "👍"
+    - img "😅"
+    - text: 10:01
+    - button "reazione ❤️. Visualizza reazioni":
+      - img "❤️"
+  - button "Apri dettagli chat di Elena Conti":
+    - img
+  - row "Elena Conti Messaggio citato Buona idea 😎 10:05":
+    - text: Elena Conti
+    - button "Messaggio citato":
+      - text: Roberto Marini
+      - button "Mi piace tanto 😅 e anche questo 😂"
+    - text: Perfetto
+    - img "🎉"
+    - text: 10:05
+  - contentinfo:
+    - button "Allega"
+    - textbox "Scrivi al gruppo Aperitivo Test":
+      - paragraph

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -1077,3 +1077,50 @@ describe("parseMessages — real WA quote structure: button-label quoted text + 
       "text should retain the reply body");
   });
 });
+
+describe("parseMessages — emoji content preservation", () => {
+  // Emoji render as `img "<glyph>"` nodes; a text-only pass dropped them, so
+  // "Mi piace 😅 molto" lost the emoji and an emoji-only message read as empty.
+  // Direct-child emoji are now interleaved into text/body; nested emoji
+  // (reactions, quoted-content) stay excluded. Fake data only.
+
+  it("interleaves inline emoji into body in document order", () => {
+    const aria = loadFixture("emoji-messages.snapshot.txt");
+    const messages = parseMessages(aria);
+    const m = messages.find((x) => x.body.startsWith("Mi piace tanto"));
+    assert.ok(m, `expected the inline-emoji message, got: ${JSON.stringify(messages, null, 2)}`);
+    assert.equal(m.body, "Mi piace tanto 😅 e anche questo 😂");
+    assert.equal(m.sender, "Roberto Marini");
+    assert.equal(m.body, m.text, "non-quote row: body must still equal text");
+  });
+
+  it("preserves an emoji-only message instead of dropping it to empty", () => {
+    const aria = loadFixture("emoji-messages.snapshot.txt");
+    const messages = parseMessages(aria);
+    const m = messages.find((x) => x.time === "10:01");
+    assert.ok(m, `expected the emoji-only message, got: ${JSON.stringify(messages, null, 2)}`);
+    assert.equal(m.body, "👍 👍 😅", "emoji-only body must contain the emoji, not be empty");
+    assert.equal(m.sender, "Roberto Marini", "continuation emoji-only msg keeps the sender");
+  });
+
+  it("excludes reaction emoji from message content", () => {
+    const aria = loadFixture("emoji-messages.snapshot.txt");
+    const messages = parseMessages(aria);
+    const m = messages.find((x) => x.time === "10:01");
+    assert.ok(m);
+    assert.ok(!m.body.includes("❤️"), "a reaction emoji must NOT leak into body");
+    assert.ok(!m.text.includes("❤️"), "a reaction emoji must NOT leak into text");
+  });
+
+  it("keeps body clean of nested quoted emoji while preserving its own emoji", () => {
+    const aria = loadFixture("emoji-messages.snapshot.txt");
+    const messages = parseMessages(aria);
+    const m = messages.find((x) => x.sender === "Elena Conti");
+    assert.ok(m, `expected Elena's quote-reply, got: ${JSON.stringify(messages, null, 2)}`);
+    assert.equal(m.quoted_sender, "Roberto Marini");
+    assert.equal(m.quoted_text, "Mi piace tanto 😅 e anche questo 😂",
+      "quoted_text retains the quoted message's emoji (from the button label)");
+    assert.equal(m.body, "Perfetto 🎉",
+      "body keeps its own emoji but not the nested quoted emoji");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the MEDIUM follow-up flagged by the 2026-06-20 visual QA run (PR #36): **emoji were silently dropped** from message content.

Emoji render as `img "<glyph>"` nodes (the accessible name *is* the emoji character), but the parser only collected `- text:` nodes. So:
- `"Mi piace 😅 molto"` → `"Mi piace molto"`
- an emoji-only message (`👍🏻 👍🏻 😅 😅 😅`) collapsed to an **empty body**

## Fix

`collectRowContent` walks the row body in document order and interleaves emoji with text. The crux is *which* emoji count as content:

- ✅ **Direct-child** imgs (4-space — direct children of the row) = the message's own emoji.
- ❌ **Nested** imgs excluded: contact avatars, **reaction emoji** (inside `button "reazione …"`), and **quoted-message emoji** (inside the quote card — already carried by `quoted_text`). A leaking reaction would be a wrong attribution of content.
- Emoji vs system icon ids (`wds-ic-*`, `msg-*`, `ic-*`, `wa-*`) distinguished **structurally**: an emoji glyph has a non-ASCII codepoint; icon ids are ASCII.

Both `body` (direct text) and `text` (any-depth text + bleed) pick up direct-child emoji, so the `body===text` invariant for non-quote rows still holds. `quoted_text` keeps the quoted message's own emoji via the button label.

## Verification

- ✅ **210 unit tests pass** (new `emoji-messages.snapshot.txt` fixture + 4 tests, fake data: inline emoji, emoji-only, reaction-excluded, quoted-emoji-clean).
- ✅ **E2E `GREENTAP_E2E=1` passes all stages** (text, image, link), exit 0 — image multimodally verified.
- ✅ **Live group**: the formerly-empty 10:04 emoji-only message now returns `👍🏻👍🏻😅😅😅`; reactions correctly excluded; 5 messages now carry emoji in `body` that were previously stripped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)