### PR TITLE
fix(read): scroll until list fully materializes — stop dropping unread-divider tail

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -353,9 +353,20 @@ async function findLoadMoreButton(page) {
  * messages whose rows haven't been mounted yet (the Ponte 1-5-26 bug,
  * 2026-05-10).
  *
- * Pins to bottom twice with a settle in between: the first scroll triggers
- * row materialization, which can shift the layout and bump scrollTop; the
- * second pin re-anchors at the new scrollHeight.
+ * Loops: pin to bottom, settle, and repeat until `scrollHeight` stops growing.
+ * Each scroll-to-bottom triggers WA to materialize the next batch of rows
+ * BELOW the current viewport, which increases `scrollHeight` — so a fixed
+ * number of scrolls can land short of the true bottom, leaving the final
+ * screenful un-mounted. We keep scrolling until the height is stable (no more
+ * rows appearing), then do one final pin + settle so those last rows are in
+ * the DOM before the caller snapshots. Without the final settle, the rows the
+ * last scroll just materialized aren't rendered yet and parseMessages silently
+ * drops them — the unread-divider tail-drop bug (2026-06-20): an active chat
+ * opened at the "N unread messages" divider returned everything up to the
+ * divider but omitted the messages below it.
+ *
+ * Bounded (max passes) so a live chat receiving a steady stream of messages
+ * can't loop forever.
  *
  * Returns true on success, false on graceful degradation (scroll container
  * not found — caller falls back to plain snapshot).
@@ -363,15 +374,26 @@ async function findLoadMoreButton(page) {
 export async function ensureScrolledToBottom(page, settleMs = 700) {
   const found = await findScrollContainer(page);
   if (!found) return false;
+  const MAX_PASSES = 6;
+  let lastHeight = -1;
+  for (let i = 0; i < MAX_PASSES; i++) {
+    const height = await page.evaluate(() => {
+      const el = document.querySelector('[data-greentap-scroll="1"]');
+      if (!el) return -1;
+      el.scrollTop = el.scrollHeight;
+      return el.scrollHeight;
+    });
+    await new Promise((r) => setTimeout(r, settleMs));
+    if (height === lastHeight) break; // bottom fully materialized — stable
+    lastHeight = height;
+  }
+  // Final pin + short settle: re-anchor at the latest scrollHeight and let the
+  // last materialized rows render before the caller takes its snapshot.
   await page.evaluate(() => {
     const el = document.querySelector('[data-greentap-scroll="1"]');
     if (el) el.scrollTop = el.scrollHeight;
   });
-  await new Promise((r) => setTimeout(r, settleMs));
-  await page.evaluate(() => {
-    const el = document.querySelector('[data-greentap-scroll="1"]');
-    if (el) el.scrollTop = el.scrollHeight;
-  });
+  await new Promise((r) => setTimeout(r, 300));
   return true;
 }
 

--- a/test/scroll-to-bottom.test.js
+++ b/test/scroll-to-bottom.test.js
@@ -4,26 +4,33 @@ import * as commands from "../lib/commands.js";
 
 /**
  * Build a fake Playwright page that records evaluate/snapshot calls and
- * lets the test program the result of each evaluate invocation.
+ * lets the test program the `scrollHeight` returned by each scroll pin.
  *
- * `findScrollContainer` and the two scrollTop pins all go through
- * `page.evaluate(fn)`. The fake exposes the call sequence so tests can
- * assert WHEN scroll-to-bottom happened relative to ariaSnapshot.
+ * `findScrollContainer` and the scrollTop pins all go through
+ * `page.evaluate(fn)`. The scroll-pin evaluate now RETURNS scrollHeight so
+ * ensureScrolledToBottom can loop until the height stabilizes; the fake feeds
+ * a programmed sequence of heights to drive that loop.
  */
-function makeFakePage({ findScrollResult = true } = {}) {
+function makeFakePage({ findScrollResult = true, heights = null } = {}) {
   const calls = [];
+  let pinIdx = 0;
   const page = {
     evaluate: async (fn) => {
-      // First call comes from findScrollContainer — record + return programmed
-      // result. Subsequent calls are the scrollTop pins; just record them.
       const src = fn.toString();
+      // findScrollContainer probes for the dataset marker.
       if (src.includes("dataset.greentapScroll")) {
         calls.push("findScrollContainer");
         return findScrollResult;
       }
+      // scroll pins read/return scrollHeight.
       if (src.includes("scrollHeight")) {
         calls.push("scrollPin");
-        return undefined;
+        if (heights) {
+          const h = pinIdx < heights.length ? heights[pinIdx] : heights[heights.length - 1];
+          pinIdx++;
+          return h;
+        }
+        return 100; // constant height → stabilizes on the 2nd pass
       }
       calls.push("evaluate:other");
       return undefined;
@@ -38,27 +45,50 @@ function makeFakePage({ findScrollResult = true } = {}) {
   return { page, calls };
 }
 
+const pins = (calls) => calls.filter((c) => c === "scrollPin").length;
+
 describe("ensureScrolledToBottom", () => {
-  it("locates scroll container, then pins scrollTop twice with a settle in between", async () => {
+  it("locates the container, scrolls until scrollHeight is stable, then a final pin", async () => {
+    // Constant height → stable on the 2nd pass: pass0 (-1→100), pass1 (100===100 break),
+    // plus the final re-anchor pin = 3 scroll pins total.
     const { page, calls } = makeFakePage({ findScrollResult: true });
-    const ok = await commands.ensureScrolledToBottom(page, 10); // tiny settle for tests
+    const ok = await commands.ensureScrolledToBottom(page, 5);
     assert.equal(ok, true, "should return true when container found");
-    assert.deepEqual(calls, ["findScrollContainer", "scrollPin", "scrollPin"]);
+    assert.equal(calls[0], "findScrollContainer");
+    assert.equal(pins(calls), 3, "two stabilizing passes + one final pin");
+    assert.ok(!calls.includes("ariaSnapshot"), "must not snapshot — that's the caller's job");
+  });
+
+  it("keeps scrolling while scrollHeight grows (virtualized rows materializing below)", async () => {
+    // Heights grow then settle: 100,200,300,300 → loop pins at 100,200,300,300
+    // (breaks when 300===300), then one final pin = 5 scroll pins.
+    const { page, calls } = makeFakePage({ heights: [100, 200, 300, 300] });
+    await commands.ensureScrolledToBottom(page, 5);
+    assert.equal(pins(calls), 5, "scrolls through each growth step, then final pin");
+  });
+
+  it("is bounded — a forever-growing (live) chat stops after MAX_PASSES, never hangs", async () => {
+    // Height grows on every pass and never stabilizes.
+    const { page, calls } = makeFakePage({ heights: [10, 20, 30, 40, 50, 60, 70, 80, 90, 100] });
+    await commands.ensureScrolledToBottom(page, 1);
+    // MAX_PASSES (6) loop pins + 1 final pin = 7. Must not exceed this.
+    assert.equal(pins(calls), 7, "bounded at MAX_PASSES loop iterations + final pin");
   });
 
   it("returns false (no-op) when scroll container is not found — graceful degradation", async () => {
     const { page, calls } = makeFakePage({ findScrollResult: false });
-    const ok = await commands.ensureScrolledToBottom(page, 10);
+    const ok = await commands.ensureScrolledToBottom(page, 5);
     assert.equal(ok, false, "should return false when container missing");
-    // Only the locate call should have happened — no scroll pins attempted.
-    assert.deepEqual(calls, ["findScrollContainer"]);
+    assert.deepEqual(calls, ["findScrollContainer"], "no scroll attempted");
   });
 
-  it("waits for the requested settle window between the two pins", async () => {
+  it("settles between passes so freshly materialized rows render before the caller snapshots", async () => {
+    // Constant height stabilizes in 2 passes; with settle=150 that's 2×150 plus
+    // the final 300ms render settle → comfortably over one settle window.
     const { page } = makeFakePage({ findScrollResult: true });
     const t0 = Date.now();
-    await commands.ensureScrolledToBottom(page, 200);
+    await commands.ensureScrolledToBottom(page, 150);
     const elapsed = Date.now() - t0;
-    assert.ok(elapsed >= 180, `should wait ~200ms, waited ${elapsed}ms`);
+    assert.ok(elapsed >= 280, `should wait through settles, waited ${elapsed}ms`);
   });
 });


### PR DESCRIPTION
## Summary

**CRITICAL** fix caught by the visual QA gate (#37): `read` on an active group returned everything up to the **"N unread messages" divider** but **omitted the messages below it**. Confirmed against a live group — `read` stopped at 13:21 while a fresh `snapshot` showed 15:14 / 15:28 / 15:29 below the divider. Dropping unread messages is the worst failure mode for a WhatsApp reader.

## Root cause

`ensureScrolledToBottom` pinned `scrollTop = scrollHeight` exactly **twice** with one settle *between* them and **no settle after the final pin**. Each scroll-to-bottom makes WhatsApp materialize the next batch of virtualized rows below the viewport, growing `scrollHeight` — so two fixed scrolls can land a screenful short, and the rows the last scroll just materialized aren't rendered when the caller snapshots. `parseMessages` then silently drops them (the parser was fine — the rows simply weren't in the DOM).

## Fix

Loop `pin → settle` until `scrollHeight` stops growing (bounded to `MAX_PASSES=6` so a live chat receiving a stream can't loop forever), then one final pin + 300 ms render settle before returning. The caller's snapshot now reflects the true bottom.

## Verification

- ✅ Live group: `read` now reaches the tail (15:28/15:29/…) instead of stalling at 13:21.
- ✅ **212 unit tests pass** — `scroll-to-bottom.test.js` rewritten for the loop: stabilize-then-final-pin, growth-driven scrolling, `MAX_PASSES` bound (no hang on a live chat), graceful degradation, settle timing.
- ✅ **E2E `GREENTAP_E2E=1`** green all stages, image multimodally verified.

## Notes
- This is **bug 1 of 2** the visual QA gate flagged on the release candidate (the other is video→text misclassification, separate PR).
- Minor adjacent bug observed (not fixed here): an `Edited`/`Modificato15:32` suffix concatenates onto the time, leaving `time:""` — will log as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)