### PR TITLE
fix(parser): classify video messages as kind:"video" (not junk text)

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -302,6 +302,45 @@ function countImageButtons(rowBody) {
 }
 
 /**
+ * Detect whether a message row is a video/media message.
+ *
+ * WhatsApp Web renders a video bubble as a player control: a direct-child
+ * (4-space) `button` that nests BOTH another `button` (the play / "Modalità
+ * PiP" / picture-in-picture control) AND a `text:` node holding the clip
+ * DURATION in M:SS form (e.g. "1:10"). The wrapper's label is locale-specific
+ * ("Modalità PiP" in Italian) so we deliberately match on STRUCTURE only.
+ *
+ * Without this, a video row fell through to `kind:"text"` and produced junk:
+ * its `text` became a leaked reaction count and its `time` became the clip
+ * duration (the duration text looks like an HH:MM clock time).
+ *
+ * The signature (nested button + nested M:SS text) is specific: quote cards
+ * have a text(sender)+button(quoted) pair but no M:SS text child; reaction and
+ * image buttons have img children, not a nested button + duration.
+ *
+ * @param {string} rowBody - Indented row body (children of the row).
+ * @returns {boolean}
+ */
+function detectVideoRow(rowBody) {
+  const lines = rowBody.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    if (!/^ {4}- button "/.test(lines[i])) continue; // direct-child labeled button
+    let hasNestedButton = false;
+    let hasDurationText = false;
+    for (let j = i + 1; j < lines.length; j++) {
+      if (/^ {6}- /.test(lines[j])) {
+        if (/^ {6}- button(\s|"|:|$)/.test(lines[j])) hasNestedButton = true;
+        if (/^ {6}- text: \d{1,2}:\d{2}$/.test(lines[j])) hasDurationText = true;
+      } else if (/^ {1,4}- /.test(lines[j]) || lines[j] === "") {
+        break; // dedented to a sibling / out of this button
+      }
+    }
+    if (hasNestedButton && hasDurationText) return true;
+  }
+  return false;
+}
+
+/**
  * Sentinel used when a message's sender cannot be resolved from the row's
  * own ARIA structure or from the carried-over previous-row sender.
  * Always-populated invariant: `sender` is never an empty string.
@@ -735,15 +774,25 @@ export function parseMessages(ariaText, options = {}) {
     // Extract text nodes from body
     const textNodes = [...rowBody.matchAll(/- text: (.+)/g)].map((m) => m[1].trim());
 
-    // Extract time (HH:MM) — may be a standalone node or at end of text
+    // Extract time (HH:MM). Prefer a DIRECT-CHILD time node (the message's own
+    // send time, at 4-space indent) over any nested time: a video's duration
+    // (e.g. "1:10") renders as a nested text node inside the player button and
+    // would otherwise be picked up as the message time. Fall back to any-depth
+    // time, then to a trailing time in the row label (body-less single-line rows).
     let time = "";
-    const timeNode = textNodes.find((t) => /^\d{1,2}:\d{2}$/.test(t));
-    if (timeNode) {
-      time = timeNode;
+    const directTime = bodyLines
+      .map((l) => l.match(/^ {4}- text: (\d{1,2}:\d{2})$/))
+      .find(Boolean);
+    if (directTime) {
+      time = directTime[1];
     } else {
-      // Time at end of row label — trailing HH:MM
-      const trailingTime = rowLabel.match(/\b(\d{1,2}:\d{2})(?:\s|$)/);
-      if (trailingTime) time = trailingTime[1];
+      const anyTime = textNodes.find((t) => /^\d{1,2}:\d{2}$/.test(t));
+      if (anyTime) {
+        time = anyTime;
+      } else {
+        const trailingTime = rowLabel.match(/\b(\d{1,2}:\d{2})(?:\s|$)/);
+        if (trailingTime) time = trailingTime[1];
+      }
     }
 
     // Detect own messages via delivery-status (receipt) icons — locale-agnostic
@@ -848,6 +897,23 @@ export function parseMessages(ariaText, options = {}) {
     // The freshness signal is single-row scoped: a sender button confirms
     // only the next row. Reset it now that this row has consumed it.
     senderConfirmedForRow = false;
+
+    // Detect video messages (structural, locale-independent). A video bubble is
+    // a player control, not a text message — emit it as kind:"video" so it
+    // isn't mistaken for a text whose content is a leaked reaction count.
+    if (detectVideoRow(rowBody)) {
+      messages.push({
+        kind: "video",
+        sender,
+        text: "",
+        time,
+        timestamp: formatTimestamp(currentDate, time),
+        quoted_sender: quotedSender,
+        quoted_text: quotedText,
+        body: "",
+      });
+      continue;
+    }
 
     // Detect image attachments in this row (structural, locale-independent).
     // A row may contain BOTH images and text caption — emit one "image" entry

--- a/test/fixtures/video-message.snapshot.txt
+++ b/test/fixtures/video-message.snapshot.txt
@@ -1,0 +1,36 @@
+- document:
+  - banner:
+    - button "Dettagli profilo":
+      - img
+    - button "Aperitivo Test clicca qui per info gruppo"
+    - button "Cerca"
+    - button "Menu"
+  - text: Oggi
+  - button "Apri dettagli chat di Roberto Marini":
+    - img
+  - row "Roberto Marini Modalità PiP 1:10 12:58 Reazioni 😂, ❤ 2 in totale. Visualizza reazioni":
+    - text: Roberto Marini
+    - button "Modalità PiP 1:10":
+      - button "Modalità PiP"
+      - text: 1:10
+    - text: 12:58
+    - button "Reazioni 😂, ❤ 2 in totale. Visualizza reazioni":
+      - img "😂"
+      - img "❤️"
+      - text: "2"
+  - button "Apri dettagli chat di Elena Conti":
+    - img
+  - row "Elena Conti Picture-in-picture 0:42 13:01":
+    - text: Elena Conti
+    - button "Picture-in-picture 0:42":
+      - button "Picture-in-picture"
+      - text: 0:42
+    - text: 13:01
+  - row "Elena Conti Bel video! 13:02":
+    - text: Elena Conti
+    - text: Bel video!
+    - text: 13:02
+  - contentinfo:
+    - button "Allega"
+    - textbox "Scrivi al gruppo Aperitivo Test":
+      - paragraph

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -1124,3 +1124,58 @@ describe("parseMessages — emoji content preservation", () => {
       "body keeps its own emoji but not the nested quoted emoji");
   });
 });
+
+describe("parseMessages — video message classification", () => {
+  // WhatsApp renders a video bubble as a player control: a button nesting a
+  // play/PiP button + an M:SS duration text. Pre-fix it fell through to
+  // kind:"text" with a leaked reaction count as `text` and the clip duration
+  // as `time`. Fake data only. Detection is structural — the wrapper label
+  // ("Modalità PiP" IT, "Picture-in-picture" EN) is deliberately ignored.
+
+  it("classifies a video bubble as kind:'video', not a text message", () => {
+    const aria = loadFixture("video-message.snapshot.txt");
+    const messages = parseMessages(aria);
+    const vids = messages.filter((m) => m.kind === "video");
+    assert.equal(vids.length, 2, `expected 2 videos, got: ${JSON.stringify(messages, null, 2)}`);
+    for (const v of vids) {
+      assert.equal(v.text, "", "video carries no text content");
+      assert.equal(v.body, "", "video carries no body content");
+    }
+  });
+
+  it("uses the message send time, not the clip duration, as `time`", () => {
+    const aria = loadFixture("video-message.snapshot.txt");
+    const messages = parseMessages(aria);
+    const v = messages.find((m) => m.kind === "video" && m.sender === "Roberto Marini");
+    assert.ok(v);
+    assert.equal(v.time, "12:58", "time must be the 12:58 send time, not the 1:10 duration");
+  });
+
+  it("does not leak a reaction count into the video message", () => {
+    const aria = loadFixture("video-message.snapshot.txt");
+    const messages = parseMessages(aria);
+    // The reaction count "2" must not appear as any message's text/body.
+    for (const m of messages) {
+      assert.notEqual(m.text, "2", `reaction count leaked into text: ${JSON.stringify(m)}`);
+    }
+  });
+
+  it("detects video structurally regardless of the locale-specific control label", () => {
+    const aria = loadFixture("video-message.snapshot.txt");
+    const messages = parseMessages(aria);
+    // The second video uses an English "Picture-in-picture" label.
+    const en = messages.find((m) => m.kind === "video" && m.sender === "Elena Conti");
+    assert.ok(en, "English-labelled video must still be detected as video");
+    assert.equal(en.time, "13:01");
+  });
+
+  it("still parses a normal text message in the same chat correctly", () => {
+    const aria = loadFixture("video-message.snapshot.txt");
+    const messages = parseMessages(aria);
+    const txt = messages.find((m) => m.body === "Bel video!");
+    assert.ok(txt, "the plain text reply must parse normally");
+    assert.equal(txt.kind, "text");
+    assert.equal(txt.sender, "Elena Conti");
+    assert.equal(txt.time, "13:02");
+  });
+});


### PR DESCRIPTION
## Summary

**Bug 2 of 2** caught by the visual QA gate (#37) on the release candidate. A video bubble was emitted as `kind:"text"` with garbage: `text` was a **leaked reaction count** (`"2"`) and `time` was the **clip duration** (`"1:10"`) instead of the send time. A consumer saw a video as a text message saying `"2"`.

## Root cause + fix

WhatsApp renders a video as a player control — a `button` nesting a play/PiP `button` **plus** an M:SS **duration** text — under a locale-specific wrapper label (`Modalità PiP` IT, `Picture-in-picture` EN).

1. **`detectVideoRow`** — structural, locale-independent detection (nested button + nested M:SS duration text; the wrapper label is ignored). Emits `kind:"video"` with empty `text`/`body`, mirroring the `kind:"image"` precedent.
2. **Time extraction prefers a direct-child (4-space) time node** over any nested time, so the duration (`1:10`, nested in the player button) no longer beats the real send time (`12:58`, a direct child). Hardens time extraction generally.
3. The **leaked reaction count** no longer surfaces (video row skips the junk text path).

## Verification

- ✅ **215 unit tests pass** — new `video-message.snapshot.txt` fixture + 5 tests, including an **English-label** case (proves locale-agnostic detection) and a normal-text regression in the same chat.
- ✅ **E2E `GREENTAP_E2E=1`** green all stages, image multimodally verified.
- ✅ **Live group**: the real video now reads `kind:"video"` `time:"12:58"` (was `kind:"text"` `text:"2"` `time:"1:10"`); zero junk `text=="2"` rows.

## Notes
- Video carries no `text`/`body` and no new field (consistent with how images are modeled). Capturing duration was left out deliberately to avoid expanding the JSON shape.
- Together with #39 (unread-divider drop), this clears both findings the visual QA gate raised on the v0.7.0 candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)