### PR TITLE
fix(parser): stop dropping body-less (label-only) message rows

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -611,7 +611,7 @@ export function parseMessages(ariaText, options = {}) {
   let msgStartIdx = -1;
   for (let i = 0; i < lines.length; i++) {
     // Match rows at 2-space indent level that are NOT inside a grid
-    const rowMatch = lines[i].match(/^  - (?:')?row "(.+?)"(?:')?:/);
+    const rowMatch = lines[i].match(/^  - (?:')?row "(.+?)"(?:')?:?\s*$/);
     if (rowMatch) {
       // Check if this row is inside a grid by looking backwards for the nearest grid or banner
       let insideGrid = false;
@@ -715,8 +715,14 @@ export function parseMessages(ariaText, options = {}) {
       }
     }
 
-    // Match message rows (at 2-space indent level)
-    const rowMatch = line.match(/^  - (?:')?row "(.+?)"(?:')?:/);
+    // Match message rows (at 2-space indent level). The trailing colon is
+    // OPTIONAL: rows WITH children render as `- row "label":` (colon, then
+    // indented children), but a body-less label-only row renders as
+    // `- row "label"` with no colon and no children. WhatsApp emits the latter
+    // for some messages (observed 2026-06-20: short received messages like a
+    // lone "?", and the most recent rows in an active chat) — without the
+    // optional colon the parser silently DROPPED every such message.
+    const rowMatch = line.match(/^  - (?:')?row "(.+?)"(?:')?:?\s*$/);
     if (!rowMatch) continue;
 
     const rowLabel = rowMatch[1];
@@ -809,8 +815,34 @@ export function parseMessages(ariaText, options = {}) {
         ? stripSenderPrefix(joined, sender)
         : joined;
     };
-    const text = buildField(allContentNodes);
-    const body = buildField(directContentNodes);
+    let text = buildField(allContentNodes);
+    let body = buildField(directContentNodes);
+
+    // Body-less label-only row: WhatsApp put the whole message in the row label
+    // with no child text nodes (bodyLines empty). Recover the message text from
+    // the label so the message isn't emitted empty (or, pre-fix, dropped along
+    // with the row). Strip a leading carried-sender name and everything from
+    // the trailing time onward (the time + any delivery-status word). Best
+    // effort for senders WA renders with an initials avatar (no sender button),
+    // where the carried sender may be stale — tracked as a follow-up — but the
+    // message is no longer lost.
+    if (bodyLines.length === 0) {
+      let lb = rowLabel;
+      if (sender && sender !== UNKNOWN_SENDER) {
+        for (const v of [`~${sender}`, `~ ${sender}`, sender]) {
+          if (lb === v) { lb = ""; break; }
+          if (lb.startsWith(v + " ")) { lb = lb.slice(v.length).trim(); break; }
+        }
+      }
+      // Cut from the LAST HH:MM in the label to the end (the send time plus any
+      // trailing delivery-status word like "Consegnato"/"Letto").
+      const times = [...lb.matchAll(/\d{1,2}:\d{2}/g)];
+      if (times.length) {
+        lb = lb.slice(0, times[times.length - 1].index).trim();
+      }
+      text = lb;
+      body = lb;
+    }
 
     // Quoted-reply detection (structural, locale-independent). The quoted
     // sender + quoted text are captured into quoted_sender / quoted_text;

--- a/test/fixtures/bodyless-rows.snapshot.txt
+++ b/test/fixtures/bodyless-rows.snapshot.txt
@@ -1,0 +1,23 @@
+- document:
+  - banner:
+    - button "Dettagli profilo":
+      - img
+    - button "Aperitivo Test clicca qui per info gruppo"
+    - button "Cerca"
+    - button "Menu"
+  - text: Oggi
+  - button "Apri dettagli chat di Roberto Marini":
+    - img
+  - row "Roberto Marini Allora a che ora arrivate 14:00":
+    - text: Roberto Marini
+    - text: Allora a che ora arrivate
+    - text: 14:00
+  - 'row "Roberto Marini Verso le sette 14:01"'
+  - row "? 14:01"
+  - button "Apri dettagli chat di Elena Conti":
+    - img
+  - row "Elena Conti Perfetto allora 14:05"
+  - contentinfo:
+    - button "Allega"
+    - textbox "Scrivi al gruppo Aperitivo Test":
+      - paragraph

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -1124,3 +1124,44 @@ describe("parseMessages — emoji content preservation", () => {
       "body keeps its own emoji but not the nested quoted emoji");
   });
 });
+
+describe("parseMessages — body-less label-only rows (2026-06-20 drop bug)", () => {
+  // WhatsApp emits some message rows as a label only, with NO trailing colon
+  // and NO child nodes (observed: short received messages like a lone "?", and
+  // the most recent rows in an active chat). The message-row regex required a
+  // trailing colon, so every such row was silently DROPPED. Fake data only.
+
+  it("does not drop body-less rows — all four messages are parsed", () => {
+    const aria = loadFixture("bodyless-rows.snapshot.txt");
+    const messages = parseMessages(aria);
+    assert.equal(messages.length, 4, `expected 4 messages, got: ${JSON.stringify(messages, null, 2)}`);
+  });
+
+  it("recovers text + time from a body-less row's label (continuation sender)", () => {
+    const aria = loadFixture("bodyless-rows.snapshot.txt");
+    const messages = parseMessages(aria);
+    const m = messages.find((x) => x.body === "Verso le sette");
+    assert.ok(m, `expected the body-less continuation, got: ${JSON.stringify(messages, null, 2)}`);
+    assert.equal(m.sender, "Roberto Marini", "continuation inherits the carried sender");
+    assert.equal(m.time, "14:01");
+    assert.equal(m.text, "Verso le sette", "sender prefix + trailing time stripped from label");
+  });
+
+  it("recovers a lone-token body-less row (e.g. \"?\") without the time", () => {
+    const aria = loadFixture("bodyless-rows.snapshot.txt");
+    const messages = parseMessages(aria);
+    const q = messages.find((x) => x.body === "?");
+    assert.ok(q, `expected the "?" message, got: ${JSON.stringify(messages, null, 2)}`);
+    assert.equal(q.sender, "Roberto Marini");
+    assert.equal(q.time, "14:01");
+  });
+
+  it("a body-less row preceded by its own sender button is attributed correctly", () => {
+    const aria = loadFixture("bodyless-rows.snapshot.txt");
+    const messages = parseMessages(aria);
+    const m = messages.find((x) => x.body === "Perfetto allora");
+    assert.ok(m, `expected Elena's body-less row, got: ${JSON.stringify(messages, null, 2)}`);
+    assert.equal(m.sender, "Elena Conti");
+    assert.equal(m.time, "14:05");
+  });
+});


### PR DESCRIPTION
## Summary

**Third completeness bug** caught by the visual QA gate (#37) on the release candidate — and the most damaging: `read` **silently dropped entire messages**. Confirmed deterministically by parsing a single captured snapshot: rows present in the aria were absent from the parsed output (9 parsed vs 13 actual).

## Root cause

WhatsApp emits some message rows as a **label only** — no trailing colon and no child nodes (observed: short received messages like a lone `?`, and the most recent rows in an active chat):

```
- row "Daniele … chi viene a che ora 15:14"      ← no colon, no children → DROPPED
- row "? 15:14"                                   ← DROPPED
```

The message-row regex required a trailing colon (`row "..."` **`:`**), so every body-less row was skipped — including messages below the unread divider that #39's scroll fix had just made reachable.

## Fix

- Make the trailing colon **optional** in the two message-row regexes (main loop + message-area-start). Chat-list and poll regexes unchanged (those rows always have bodies).
- When a row has no body lines, recover content from the **label**: strip a leading carried-sender name and everything from the trailing time onward (send time + delivery-status word).

## Known limitation (filed as follow-up, not this PR)

A body-less row from a sender WA renders with an **initials avatar** (no sender button with an `img` child) inherits a stale carried sender — the message now **appears** but may be mis-attributed. Dropping it silently was strictly worse. Tracked as issue #5.

## Verification

- ✅ Re-parsing the captured snapshot now yields **13 messages (was 9)**, with the previously-dropped rows present.
- ✅ **214 unit tests pass** — new `bodyless-rows.snapshot.txt` fixture + 4 tests (no-drop, label text+time recovery, lone-token `?`, own-sender-button attribution).
- ✅ **E2E `GREENTAP_E2E=1`** green all stages, image multimodally verified.

Bug 3 of 3 the visual QA gate flagged. With #39 + #40 + this, the three message-loss / misclassification bugs are closed; #4 (edited-time), #5 (initials-avatar sender), #6 (poll kind) are filed as follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)