### PR TITLE
chore(release): v0.7.0 — bump version + document kind:"video"

### DIFF
--- a/.claude/skills/greentap/SKILL.md
+++ b/.claude/skills/greentap/SKILL.md
@@ -118,7 +118,7 @@ Each message in `read --json` carries these fields (additive over time — older
 | `quoted_sender` | string \| null | New: author of the quoted message when this is a reply-with-quote. |
 | `quoted_text` | string \| null | New: text of the quoted message. |
 | `links` | `[{href, text}]` | http(s) URLs recovered from the DOM (handles WhatsApp's truncated previews). |
-| `kind` | string | `"text"` or `"image"` (more kinds may appear in future versions). |
+| `kind` | string | `"text"`, `"image"`, or `"video"` (more kinds may appear in future versions). |
 | `imageId` | string | Only on `kind: "image"`. Stable across reads of the same DOM. Use with `fetch-images` to materialize. |
 
 Outbound messages are identified by `sender === "You"` — there is no separate boolean `is_self` field. Pair with `whoami` to map `"You"` to a real account.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "greentap",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "CLI driver for WhatsApp Web via Playwright",
   "main": "greentap.js",
   "bin": {


### PR DESCRIPTION
Release-prep for **v0.7.0**: bump `package.json` 0.6.0 → 0.7.0 and update the SKILL.md read-output contract to list the new `"video"` kind (skill-coherence item).

v0.7.0 is a sender-attribution + read-fidelity pass, all found/validated via the new agent-governed visual QA gate:
- **sender**: strip trailing phone, parse button-wrapped quote cards, fix own-message `wds-ic-*` icon (#36); emoji preserved in text/body (#38)
- **read completeness**: scroll until list materializes / unread-divider tail (#39); parse body-less label-only rows (#41)
- **media**: classify videos as `kind:"video"` (#40)
- **process**: agent-governed visual QA gate — TESTING.md + scripts/qa-visual.mjs (#37)

Known limits (filed): #42 edited-message time, #43 initials-avatar sender, #44 poll kind.

221 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)