### PR TITLE
fix(parser): resolve chats whose name contains emoji

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -9,7 +9,7 @@
 import { writeFileSync, mkdirSync } from "fs";
 import { homedir } from "os";
 import { join } from "path";
-import { parseChatList, parseMessages, parseSearchResults, parsePollMessages, UNKNOWN_SENDER } from "./parser.js";
+import { parseChatList, parseMessages, parseSearchResults, parsePollMessages, normalizeChatName, UNKNOWN_SENDER } from "./parser.js";
 import { assertE2EAllowed, filterToSandbox, isE2EMode } from "./e2e-guard.js";
 
 /** Downloads cache root. Per-chat subdir, 0o600 file mode — user-local only. */
@@ -68,6 +68,12 @@ export async function waitForMessagePanel(page) {
 export async function navigateToChat(page, chatName, localeConfig, index = undefined) {
   assertE2EAllowed(chatName);
 
+  // Normalized query, used for every name comparison below. Strips WhatsApp's
+  // emoji-font artifacts (e.g. the U+E000 PUA char injected after some emoji)
+  // so a user-typed name with emoji matches WA's rendered accessible name.
+  // Match semantics stay EXACT — see normalizeChatName.
+  const normQuery = normalizeChatName(chatName);
+
   // Fast-path: already in the target chat. When a chat is open, the chat
   // header exposes a button whose aria label is either the chat name
   // (direct messages) or the chat name followed by a locale-specific
@@ -93,9 +99,15 @@ export async function navigateToChat(page, chatName, localeConfig, index = undef
       .getByRole("banner")
       .last()
       .ariaSnapshot({ timeout: 500 });
-    const escaped = chatName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    const headerRe = new RegExp(`button "${escaped}(?: [^"]*)?"`);
-    if (headerRe.test(headerAria)) return;
+    // Compare normalized button labels (not a raw regex): a direct-message
+    // header button is the exact chat name; a group header button is the name
+    // followed by a locale-specific suffix. Normalizing both sides also lets
+    // emoji-named chats hit the fast-path instead of always re-navigating.
+    const headerButtons = [...headerAria.matchAll(/button "((?:[^"\\]|\\.)*)"/g)].map((m) => m[1]);
+    if (headerButtons.some((label) => {
+      const norm = normalizeChatName(label);
+      return norm === normQuery || norm.startsWith(normQuery + " ");
+    })) return;
   } catch {
     // If aria read fails (no banner, timeout, Playwright error), fall
     // through to the normal grid-or-search path. Graceful degradation —
@@ -116,7 +128,7 @@ export async function navigateToChat(page, chatName, localeConfig, index = undef
   if (gridReady) {
     const gridAria = await chatGrid.ariaSnapshot();
     const chats = parseChatList(gridAria, localeConfig);
-    const matches = chats.filter((c) => c.name === chatName);
+    const matches = chats.filter((c) => normalizeChatName(c.name) === normQuery);
     if (matches.length > 1) {
       if (index === undefined) {
         const list = matches.map((c, i) => `  ${i + 1}. ${c.name} (${c.time}) — ${c.lastMessage}`).join("\n");
@@ -135,7 +147,7 @@ export async function navigateToChat(page, chatName, localeConfig, index = undef
     // tells the user what to type to disambiguate.
     if (matches.length === 0) {
       const partials = chats.filter(
-        (c) => c.name !== chatName && c.name.toLowerCase().includes(chatName.toLowerCase()),
+        (c) => normalizeChatName(c.name) !== normQuery && normalizeChatName(c.name).toLowerCase().includes(normQuery.toLowerCase()),
       );
       if (partials.length > 0) {
         const list = partials
@@ -168,24 +180,31 @@ export async function navigateToChat(page, chatName, localeConfig, index = undef
   await page.keyboard.type(chatName, { delay: 30 });
 
   try {
-    await page.getByRole("grid").first().getByRole("row").filter({ hasText: chatName }).first().waitFor({ timeout: 5000 });
+    // Wait for the results grid to populate (any row), then let the parsed +
+    // normalized match below decide. We deliberately do NOT gate on
+    // `hasText: chatName`: emoji in a name render as `img` nodes (no
+    // textContent) and WA injects PUA chars, so a hasText substring check
+    // spuriously fails for emoji-named chats even when they're in the results.
+    await page.getByRole("grid").first().getByRole("row").first().waitFor({ timeout: 5000 });
   } catch {
     await page.keyboard.press("Escape");
     await page.keyboard.press("Escape");
     throw new Error(`Chat "${chatName}" not found`);
   }
 
-  // Parse search results for exact name matches (may be >1)
+  // Parse search results for exact name matches (may be >1). Matching uses the
+  // function-level normQuery so emoji-font artifacts (e.g. injected U+E000)
+  // don't break the comparison; semantics stay exact — see normalizeChatName.
   const searchAria = await page.locator(":root").ariaSnapshot();
   const searchResults = parseSearchResults(searchAria, localeConfig);
-  const searchMatches = searchResults.filter((c) => c.name === chatName);
+  const searchMatches = searchResults.filter((c) => normalizeChatName(c.name) === normQuery);
   if (searchMatches.length === 0) {
     // Surface partial matches in the search panel as candidates so the user
     // can disambiguate without re-typing variants. Match semantics stay
     // exact (we don't auto-select on partial matches — that's how short
     // queries like "Foot" silently picked the wrong chat in the past).
     const partials = searchResults.filter(
-      (c) => c.name !== chatName && c.name.toLowerCase().includes(chatName.toLowerCase()),
+      (c) => normalizeChatName(c.name) !== normQuery && normalizeChatName(c.name).toLowerCase().includes(normQuery.toLowerCase()),
     );
     await page.keyboard.press("Escape");
     await page.keyboard.press("Escape");

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -101,6 +101,36 @@ const ITALIAN_FALLBACK = {
 };
 
 /**
+ * Normalise a chat name for robust exact-matching of a user-supplied query
+ * against the name WhatsApp Web renders into its accessible tree.
+ *
+ * WhatsApp Web renders emoji via a custom font that injects invisible
+ * artifacts the user cannot type, which break a naive `rendered === typed`
+ * comparison. This strips them while PRESERVING the visible emoji code points
+ * (so distinct emoji names stay distinguishable and exact-match semantics —
+ * intentional, see navigateToChat — are kept):
+ *   - Private Use Area code points (e.g. U+E000 injected after U+26BD).
+ *   - Variation selectors (U+FE00–U+FE0F) — an emoji may render with or
+ *     without one depending on font, but the user can't reliably type it.
+ *   - Non-breaking / narrow / zero-width spaces, collapsed to a single space.
+ * NFC normalisation makes equivalent composed/decomposed forms compare equal.
+ *
+ * @param {string|null|undefined} name
+ * @returns {string}
+ */
+export function normalizeChatName(name) {
+  if (name == null) return "";
+  return name
+    .normalize("NFC")
+    .replace(/[\uE000-\uF8FF]/gu, "") // BMP Private Use Area (WA emoji-font glyphs)
+    .replace(/[\u{F0000}-\u{10FFFF}]/gu, "") // supplementary-plane PUA (planes 15-16)
+    .replace(/[\uFE00-\uFE0F]/gu, "") // variation selectors
+    .replace(/[\u00A0\u202F\u2007\u200B]/gu, " ") // nbsp / narrow-nbsp / figure / zero-width
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
  * Parse chat entries from a WhatsApp Web aria snapshot.
  * Finds the first grid element and extracts chat rows from it.
  * @param {string} ariaText
@@ -121,11 +151,26 @@ export function parseChatList(ariaText, localeConfig) {
   while ((match = rowRegex.exec(ariaText)) !== null) {
     const rowBody = match[2];
 
-    // Extract name + time from the inner gridcell (second gridcell, the one with just name+time)
-    const nameTimeMatch = rowBody.match(/- gridcell "(.+?)"\n/);
-    if (!nameTimeMatch) continue;
+    // Extract name + time from the inner gridcell (the SECOND gridcell — the
+    // first is the outer wrapper whose label also contains the last message).
+    //
+    // We must NOT key off "leaf gridcell" (label line ending in `"\n`): when a
+    // chat NAME contains emoji, WhatsApp renders that gridcell with child nodes
+    // (`text:` + `img "emoji"`), so its line ends in `":` (has children). The
+    // old regex `/- gridcell "(.+?)"\n/` only matched leaf gridcells and thus
+    // silently dropped emoji-named chats — see test "does not drop chats whose
+    // name contains emoji". Collect every gridcell label (quote-aware so escaped
+    // `\"` inside a name doesn't truncate it) and take the second.
+    //
+    // The outer wrapper gridcell is frequently YAML single-quoted
+    // (`- 'gridcell "..."'`) because its label contains a `: ` from the last
+    // message; the `(?:')?` keeps it in the list so the positional [0]=outer,
+    // [1]=inner relationship holds (otherwise the count shifts and [1] lands on
+    // the unread-count gridcell).
+    const gridLabels = [...rowBody.matchAll(/- (?:')?gridcell "((?:[^"\\]|\\.)*)"/g)].map((m) => m[1]);
+    if (gridLabels.length < 2) continue;
 
-    const nameTimeStr = nameTimeMatch[1];
+    const nameTimeStr = gridLabels[1];
 
     const timeMatch = nameTimeStr.match(timePattern);
 

--- a/test/fixtures/emoji-chat-name.snapshot.txt
+++ b/test/fixtures/emoji-chat-name.snapshot.txt
@@ -1,0 +1,19 @@
+- grid "Lista delle chat":
+    - 'row "Calcetto del Giovedì 🤸 ⚽ 🏃 20:56 ~Marco : Sticker"':
+      - 'gridcell "Calcetto del Giovedì 🤸 ⚽ 🏃 20:56 ~Marco : Sticker"':
+        - img
+        - gridcell "Calcetto del Giovedì 🤸 ⚽ 🏃 20:56":
+          - text: Calcetto del Giovedì
+          - img "🤸"
+          - img "⚽"
+          - img "🏃"
+          - text: "20:56"
+        - text: "~Marco : Sticker"
+        - gridcell
+    - 'row "Futsal Group 17:36 Sergio L. : Ok a dopo ciao cari 1 messaggio non letto"':
+      - 'gridcell "Futsal Group 17:36 Sergio L. : Ok a dopo ciao cari 1 messaggio non letto"':
+        - img
+        - gridcell "Futsal Group 17:36"
+        - text: "Sergio L. : Ok a dopo ciao cari"
+        - gridcell "1 messaggio non letto": "1"
+  - text: end

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "fs";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
-import { parseChatList, printChats, parseMessages, printMessages, parseSearchResults, parsePollMessages } from "../lib/parser.js";
+import { parseChatList, printChats, parseMessages, printMessages, parseSearchResults, parsePollMessages, normalizeChatName } from "../lib/parser.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const FIXTURES = join(__dirname, "fixtures");
@@ -63,6 +63,24 @@ describe("parseChatList", () => {
     const hasDay = times.some((t) => /^(lunedì|martedì|mercoledì|giovedì|venerdì|sabato|domenica|ieri|oggi)$/i.test(t));
     assert.ok(hasHHMM, "should have HH:MM format times");
     assert.ok(hasDay, "should have day name format times");
+  });
+
+  // Regression: chats whose NAME contains emoji render the name+time gridcell
+  // with child nodes (text + `img "emoji"`), so its aria line ends with `":`
+  // (has children) instead of `"` + newline (leaf). The old extraction regex
+  // `/- gridcell "(.+?)"\n/` only matched leaf gridcells, so emoji-named chats
+  // were silently dropped from the parsed list — manifesting as "Chat not
+  // found" on read/poll-results/snapshot and empty search results, even though
+  // `snapshot chats` (raw aria) showed the chat. See navigateToChat resolution.
+  it("does not drop chats whose name contains emoji", () => {
+    const aria = loadFixture("emoji-chat-name.snapshot.txt");
+    const chats = parseChatList(aria);
+    const emoji = chats.find((c) => c.name.startsWith("Calcetto del Giovedì"));
+    assert.ok(emoji, `emoji-named chat should be parsed, got: ${JSON.stringify(chats)}`);
+    assert.equal(emoji.time, "20:56");
+    assert.ok(emoji.name.includes("⚽"), "emoji should be preserved in the name");
+    // The neighbouring plain chat must still parse (no regression).
+    assert.ok(chats.find((c) => c.name === "Futsal Group"), "plain chat still parsed");
   });
 
   it("returns empty array for empty input", () => {
@@ -131,6 +149,35 @@ describe("parseChatList", () => {
     assert.equal(chats.length, 1);
     assert.equal(chats[0].name, "Sport Club");
     assert.equal(chats[0].unreadCount, 61);
+  });
+});
+
+describe("normalizeChatName", () => {
+  it("strips Private Use Area artifacts injected by WhatsApp's emoji font", () => {
+    // WhatsApp Web renders some emoji via a custom font that injects a PUA
+    // code point (e.g. U+E000 after ⚽) into the accessible name. Users cannot
+    // type it, so the raw name must be normalised before exact-matching.
+    const typed = "Calcetto del Giovedì 🤸 ⚽ 🏃";
+    const rendered = typed.replace("⚽", "⚽\u{E000}"); // WA injects a PUA char here
+    assert.notEqual(rendered, typed, "raw strings differ (the bug)");
+    assert.equal(normalizeChatName(rendered), normalizeChatName(typed));
+  });
+
+  it("is insensitive to emoji variation selectors", () => {
+    assert.equal(normalizeChatName("Foot ⚽️"), normalizeChatName("Foot ⚽"));
+  });
+
+  it("collapses non-breaking spaces and trims", () => {
+    assert.equal(normalizeChatName("A  B "), "A B");
+  });
+
+  it("preserves distinct emoji so different names stay distinguishable", () => {
+    assert.notEqual(normalizeChatName("Foot ⚽"), normalizeChatName("Foot 🏀"));
+  });
+
+  it("handles null/undefined safely", () => {
+    assert.equal(normalizeChatName(null), "");
+    assert.equal(normalizeChatName(undefined), "");
   });
 });
 


### PR DESCRIPTION
## Problem

`read`, `poll-results`, and `search` returned **"Chat not found" / `[]`** for any chat whose **name contains emoji**, even though `snapshot chats` (raw aria) listed it. Reproduced on a real emoji-named group (membership confirmed — it was a selection/match bug, not membership).

## Root cause (two compounding issues, same trigger = emoji in the *name*)

1. **Primary — the parser dropped the row.** When a chat name contains emoji, WhatsApp renders the name+time gridcell with *child nodes* (`text:` + `img "emoji"`), so its aria line ends in `":` (has children) instead of `"`+newline (leaf). `parseChatList`'s regex `/- gridcell "(.+?)"\n/` matched only *leaf* gridcells → emoji-named chats silently vanished from the parsed list.
2. **Secondary — injected PUA char.** WhatsApp injects a Private Use Area code point (e.g. **U+E000** after ⚽) into the accessible name. Un-typeable, so an exact `name === query` comparison failed even when parsing succeeded.

## Fix

- **`parseChatList`**: extract the inner name+time gridcell *positionally* (`[0]`=outer wrapper, `[1]`=inner), quote-aware and tolerant of the YAML single-quoted outer wrapper. No longer drops child-bearing (emoji) gridcells.
- **`normalizeChatName`** (new, exported): strip PUA glyphs, variation selectors, nbsp/zero-width spaces + NFC-normalise, **preserving visible emoji** so distinct emoji names stay distinguishable.
- **`navigateToChat`**: match via `normalizeChatName` in the fast-path, grid path, and search fallback; drop the emoji-hostile `hasText` gate. **Exact-match semantics + `--index` disambiguation preserved** — deliberately did *not* switch to fuzzy matching (respects the existing "short query picked the wrong chat" guard).

## Verification

- ✅ **227 unit tests pass** (new parser regression test + `normalizeChatName` unit tests, PII-safe fixture `emoji-chat-name.snapshot.txt`).
- ✅ **`GREENTAP_E2E` suite green** — preflight/text/image/link, image multimodally verified ("GREENTAP-E2E" legible).
- ✅ **Live read-only on a real emoji-named group** — `read`, `poll-results`, `search` all resolve it now.

## Out of scope — separate pre-existing bug found

`snapshot messages --chat` returns **"Message panel not found" for *all* chats** (not emoji-related): its `getByRole("application")` selector is stale — the message panel has no `application`/`main`/`region`/`log` container role. `read` works because it snapshots `:root`. Recommend a dedicated follow-up fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)