### PR TITLE
chore(release): v0.7.1 — resolve chats whose name contains emoji

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,9 +1,9 @@
 ## Strategic context
-Priority: medium — stable; v0.7.0 shipped (sender attribution + read fidelity + agent-governed visual QA gate)
+Priority: medium — stable; v0.7.1 shipped (patch: resolve chats whose name contains emoji #46); v0.7.0 (sender attribution + read fidelity + agent-governed visual QA gate)
 Current phase: Phase 10 — read-fidelity hardening (v0.7.0 visual-QA follow-ups: edited-message time #42, initials-avatar sender #43, poll kind #44)
 Blocks: nothing
 Blocked by: nothing
-Last updated: 2026-06-20
+Last updated: 2026-06-23
 → Full strategic context: psacc/docs/ROADMAP.md
 
 ---
@@ -137,6 +137,7 @@ Status: deferred. Single-agent usage works. Re-open if multiple parallel agents 
 - [ ] **Sticker visibility** — parser `kind: "sticker"` + `fetchStickers` download. Reuses fetchImages mechanics with a different DOM marker. Tracked in task tracker.
 - [ ] **Sender-inheritance hardening** — current orphan-row recovery blindly inherits previous-row sender. Tighten to require a "same-author" hint (e.g. `msg-dblcheck` for own, structural cue) and prefer `(unknown)` when ambiguous. Tracked in task tracker.
 - [ ] **Performance hygiene** — concrete proposals reviewed by 3 independent agents, accepted only if no functionality loss. Likely targets: replace hardcoded `setTimeout` waits with element-based `waitFor`, reduce review-agent prompt size for diffs <30 LOC, cheaper overlay-dismiss alternative to `page.reload()` between e2e stages.
+- [ ] **`snapshot messages` stale selector** (low priority; debug-only command) — the `messages` scope uses `page.getByRole("application")`, but WA Web's message panel has no `application`/`main`/`region`/`log` container role, so it always returns "Message panel not found" for ALL chats. Not emoji-related; `read` (the real path) is unaffected since it snapshots `:root`. Fix: fall back to `:root` or scope to the region after the chat-header banner. Discovered during the v0.7.1 emoji-chat-name QA.
 
 ### Phase 10 — Voice + documents (deferred, no spike yet)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "greentap",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "CLI driver for WhatsApp Web via Playwright",
   "main": "greentap.js",
   "bin": {


### PR DESCRIPTION
Patch release **v0.7.1**. Bumps `package.json` 0.7.0 → 0.7.1 and updates `ROADMAP.md`.

### Ships
- **fix(parser): resolve chats whose name contains emoji** (#46) — `read` / `poll-results` / `search` no longer fail with "Chat not found" / `[]` for emoji-named chats. Root cause: `parseChatList` dropped rows whose name+time gridcell had emoji child nodes, plus WA injects an un-typeable U+E000 PUA char that broke exact matching. Fixed via positional gridcell extraction + `normalizeChatName`. Exact-match + `--index` semantics preserved.

### Backlog logged (Phase 9, low priority)
- `snapshot messages` uses a stale `getByRole("application")` selector and returns "Message panel not found" for **all** chats — debug-only command; `read` (the real path) is unaffected. Deferred per maintainer.

### Verification (from #46)
- 227 unit tests pass · `GREENTAP_E2E` suite green (image multimodally verified) · live read-only confirmation on a real emoji-named group.

After merge: tag `v0.7.1` + GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)